### PR TITLE
Replace find_by with find_by_email to be compatible with rails 3.2

### DIFF
--- a/lib/simple_token_authentication/acts_as_token_authentication_handler.rb
+++ b/lib/simple_token_authentication/acts_as_token_authentication_handler.rb
@@ -27,7 +27,7 @@ module SimpleTokenAuthentication
       end
 
       user_email = params[:user_email].presence
-      user = user_email && User.find_by(email: user_email)
+      user = user_email && User.find_by_email(user_email)
 
       # Notice how we use Devise.secure_compare to compare the token
       # in the database with the token given in the params, mitigating


### PR DESCRIPTION
find_by was introduced in rails 4, since a lot of apps still uses rails 3.2, it is good to use find_by_email since i had to define find_by method in user.b model to get the gem working perfectly.
