### PR TITLE
Devise authentication should be optional

### DIFF
--- a/lib/simple_token_authentication/acts_as_token_authentication_handler.rb
+++ b/lib/simple_token_authentication/acts_as_token_authentication_handler.rb
@@ -11,8 +11,6 @@ module SimpleTokenAuthentication
       private :header_email_name
       # This is our new function that comes before Devise's one
       before_filter :authenticate_entity_from_token!
-      # This is Devise's authentication
-      before_filter :authenticate_entity!
 
       # This is necessary to test which arguments were passed to sign_in
       # from authenticate_entity_from_token!


### PR DESCRIPTION
I'm working on JSON API for iOS and I want return different data for unauthenticated and authenticated.  acts_as_token_authentication_handler_for forces authentication, but without authenticate_entity filter it is possible get data. (I'm managing authorization rules in pundit)
