### PR TITLE
Use .exists? when checking token existence

### DIFF
--- a/lib/simple_token_authentication/acts_as_token_authenticatable.rb
+++ b/lib/simple_token_authentication/acts_as_token_authenticatable.rb
@@ -18,7 +18,7 @@ module SimpleTokenAuthentication
     def generate_authentication_token
       loop do
         token = Devise.friendly_token
-        break token unless self.class.where(authentication_token: token).first
+        break token unless self.class.exists?(authentication_token: token)
       end
     end
 


### PR DESCRIPTION
Use `.exists` inside `generate_authentication_token` method as discussed in https://github.com/gonzalo-bulnes/simple_token_authentication/issues/55
