### PR TITLE
Add parameters before_filter and fallback_to_devise

### DIFF
--- a/lib/simple_token_authentication/acts_as_token_authentication_handler.rb
+++ b/lib/simple_token_authentication/acts_as_token_authentication_handler.rb
@@ -104,18 +104,21 @@ module SimpleTokenAuthentication
 
     module ClassMethods
       def acts_as_token_authentication_handler_for(entity, options = {})
-        options = { fallback_to_devise: true }.merge(options)
+        options = { before_filter: true, fallback_to_devise: true }.merge(options)
 
         SimpleTokenAuthentication::ActsAsTokenAuthenticationHandlerMethods.set_entity entity
         include SimpleTokenAuthentication::ActsAsTokenAuthenticationHandlerMethods
 
-        # This is our new function that comes before Devise's one
-        before_filter :authenticate_entity_from_token!
-        if options[:fallback_to_devise]
-          # This is Devise's authentication
-          before_filter :authenticate_entity!
-        else
-          before_filter :require_authentication_of_entity!
+        if options[:before_filter]
+          # This is our new function that comes before Devise's one
+          before_filter :authenticate_entity_from_token!
+
+          if options[:fallback_to_devise]
+            # This is Devise's authentication
+            before_filter :authenticate_entity!
+          else
+            before_filter :require_authentication_of_entity!
+          end
         end
       end
 


### PR DESCRIPTION
Commit makes before_filters are optional
- `before_filter` - disables all before_filters
- `fallback_to_devise` - disables `before_filter :authenticate_entity!`

Example of usage:

``` ruby
class HomeController < ApplicationController
  acts_as_token_authentication_handler_for User, before_filter: false

  before_filter :authenticate_entity_from_token!, only: :destroy

  def index
    # ... Accessible for unauthenticated users ...
  end

  def destroy
    # ... Only for authenticated users...
  end
end
```
