### PR TITLE
Fix OSX sed compatibility for cucumber features steps

### DIFF
--- a/features/step_definitions/dummy_app_steps.rb
+++ b/features/step_definitions/dummy_app_steps.rb
@@ -45,7 +45,7 @@ Given /^I have a dummy app with a Devise-enabled (\w+)$/ do |model|
 
   # See http://stackoverflow.com/a/10587853
   steps %Q{
-    And I run `sed -i "1s/^/require 'devise';/" config/application.rb`
+    And I run `sed -i '' "1s/^/require 'devise';/" config/application.rb`
     And I write to "config/initializers/simple_token_authentication.rb" with:
       """
       require 'simple_token_authentication'
@@ -100,7 +100,7 @@ Given /^I have a dummy app with a Devise-enabled (\w+) and (\w+)$/ do |first_mod
 
   # See http://stackoverflow.com/a/10587853
   steps %Q{
-    And I run `sed -i "1s/^/require 'devise';/" config/initializers/devise.rb`
+    And I run `sed -i '' "1s/^/require 'devise';/" config/initializers/devise.rb`
     And I write to "config/initializers/simple_token_authentication.rb" with:
       """
       require 'simple_token_authentication'


### PR DESCRIPTION
Cucumber tests were failing on OSX since Mac sed requires an extension to be named for backup files, whereas it is optional for BSD sed
#70
