### PR TITLE
Devise strategy - add basic backward compatibility

### DIFF
--- a/lib/simple_token_authentication.rb
+++ b/lib/simple_token_authentication.rb
@@ -1,4 +1,6 @@
 require 'devise'
+require 'simple_token_authentication/acts_as_token_authenticatable'
+require 'simple_token_authentication/acts_as_token_authentication_handler'
 
 module Devise
   mattr_accessor :token_header_names

--- a/lib/simple_token_authentication/acts_as_token_authenticatable.rb
+++ b/lib/simple_token_authentication/acts_as_token_authenticatable.rb
@@ -1,0 +1,13 @@
+module SimpleTokenAuthentication
+  module ActsAsTokenAuthenticatable
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def acts_as_token_authenticatable(options = {})
+        ActiveSupport::Deprecation.warn "`acts_as_token_authenticatable()` is deprecated and may be removed from future releases", caller
+        devise :simple_token_authenticatable
+      end
+    end
+  end
+end
+ActiveRecord::Base.send :include, SimpleTokenAuthentication::ActsAsTokenAuthenticatable

--- a/lib/simple_token_authentication/acts_as_token_authentication_handler.rb
+++ b/lib/simple_token_authentication/acts_as_token_authentication_handler.rb
@@ -1,0 +1,15 @@
+module SimpleTokenAuthentication
+  module ActsAsTokenAuthenticationHandler
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def acts_as_token_authentication_handler_for(entity, options = {})
+        ActiveSupport::Deprecation.warn "`acts_as_token_authentication_handler_for()` is deprecated and may be removed from future releases.", caller
+        ActiveSupport::Deprecation.warn "`:fallback_to_devise` option is no longer supported.", caller if options[:fallback_to_devise]
+        before_filter :"authenticate_#{entity.name.singularize.underscore}!",
+                      options.slice(:only, :except)
+      end
+    end
+  end
+end
+ActionController::Base.send :include, SimpleTokenAuthentication::ActsAsTokenAuthenticationHandler


### PR DESCRIPTION
Reintroduce acts_as_token_authentication_handler_for and acts_as_token_authenticatable
These methods can provide aliases for the new API but also give deprecation warning.

After merging this to `spike-refactor-concerns-to-devise-strategy` branch, you should be able to use code from `spike-refactor-concerns-to-devise-strategy` branch in your existing application and in 99% of cases it should work :)
