### PR TITLE
Fix the identity unamiguosity in the license

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ License
 -------
 
     Simple Token Authentication
-    Copyright (C) 2013 Gonzalo Bulnes Guilpain
+    Copyright (C) 2013 Gonzalo Bulnes Guilpain (*not* José Valim)
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
In the beginning of readme there is a disclaimer that you, Gonzalo Bulnes Guilpain, are _not_ José Valim. Although it is in the readme, I feel that this fact should also be written in the license, so that we avoid any legal confusion that might potentially occur.
