### PR TITLE
Devise strategy - bring back old method of configuration

### DIFF
--- a/lib/simple_token_authentication.rb
+++ b/lib/simple_token_authentication.rb
@@ -1,11 +1,8 @@
 require 'devise'
+require 'simple_token_authentication/configuration'
 
-module Devise
-  mattr_accessor :token_header_names
-  @@token_header_names = {}
-
-  mattr_accessor :sign_in_token
-  @@sign_in_token = false
+module SimpleTokenAuthentication
+  extend Configuration
 end
 
 Devise.add_module(

--- a/lib/simple_token_authentication/configuration.rb
+++ b/lib/simple_token_authentication/configuration.rb
@@ -1,0 +1,15 @@
+module SimpleTokenAuthentication
+  module Configuration
+
+    mattr_accessor :header_names
+    mattr_accessor :sign_in_token
+
+    # Default configuration
+    @@header_names = {}
+    @@sign_in_token = false
+
+    def configure
+      yield self if block_given?
+    end
+  end
+end

--- a/lib/simple_token_authentication/strategy.rb
+++ b/lib/simple_token_authentication/strategy.rb
@@ -20,7 +20,7 @@ module Devise
       end
 
       def store
-        ::Devise.sign_in_token
+        ::SimpleTokenAuthentication.sign_in_token
       end
 
       private
@@ -43,7 +43,7 @@ module Devise
       end
 
       def configured_headings
-        ::Devise.token_header_names[snake_resource_name.to_sym] || {}
+        ::SimpleTokenAuthentication.header_names[snake_resource_name.to_sym] || {}
       end
 
       def token_header


### PR DESCRIPTION
In this commit - https://github.com/adamniedzielski/simple_token_authentication/commit/f72f6e54237263ba92e97e6f1386f99fbe41f2c8 @jbender changed the way how simple_token_authentication can be configured. I think that the previous way was better, because it lets you do config on `SimpleTokenAuthentication` module instead of `Devise` module. 

This encourages gem users to create separate initializer with configuration related to SimpleTokenAuthentication. In my opinion this is good - there are already many configuration options in `Devise` module, so having separate configuration specific only to SimpleTokenAuthentication is good.

What do you think?
