### PR TITLE
Custom authentication parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ SimpleTokenAuthentication.configure do |config|
   #
   # config.header_names = { user: { authentication_token: 'X-User-Token', email: 'X-User-Email' } }
 
+  # Configure the name of the attribute used to authenticate.
+  # This attribute should exist in your model
+  #
+  # Default parameter follows the following pattern:
+  # { entity: 'email' }
+  #
+  # This parameter should match the main parameter you set up in your Devise configuration.
+  # Check: https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-sign-in-using-their-username-or-email-address#tell-devise-to-use-username-in-the-authentication_keys
+  #
+  # config.header_names = { user: 'email' }
+
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ SimpleTokenAuthentication.configure do |config|
   # This parameter should match the main parameter you set up in your Devise configuration.
   # Check: https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-sign-in-using-their-username-or-email-address#tell-devise-to-use-username-in-the-authentication_keys
   #
-  # config.header_names = { user: 'email' }
+  # config.auth_parameter_name = { user: 'email' }
 
 end
 ```

--- a/lib/simple_token_authentication/configuration.rb
+++ b/lib/simple_token_authentication/configuration.rb
@@ -3,6 +3,8 @@ module SimpleTokenAuthentication
 
     mattr_accessor :header_names
     mattr_accessor :sign_in_token
+    mattr_accessor :auth_parameter_name
+
 
     # Default configuration
     @@header_names = {}

--- a/lib/simple_token_authentication/configuration.rb
+++ b/lib/simple_token_authentication/configuration.rb
@@ -9,6 +9,7 @@ module SimpleTokenAuthentication
     # Default configuration
     @@header_names = {}
     @@sign_in_token = false
+    @@auth_parameter_name = {}
 
     def configure
       yield self if block_given?


### PR DESCRIPTION
Implementing the authentication parameter to be configurable. (Instead of hardcoded `email`)

Example:

    SimpleTokenAuthentication.configure do |config|
      config.auth_parameter_name = { user: 'your_parameter_name' }
    end

#68 