### PR TITLE
Allow for using any model field as identifier and not only :email.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ SimpleTokenAuthentication.configure do |config|
   #   And the token authentification handler for SuperAdmin watches the following headers:
   #     `X-Admin-Auth-Token, X-SuperAdmin-Email`
   #
-  # config.header_names = { user: { authentication_token: 'X-User-Token', email: 'X-User-Email' } }
+  # config.header_names = { user: { authentication_token: 'X-User-Token', :identifier_field: :email, identifier: 'X-User-Email' } }
 
 end
 ```

--- a/lib/simple_token_authentication/acts_as_token_authentication_handler.rb
+++ b/lib/simple_token_authentication/acts_as_token_authentication_handler.rb
@@ -59,15 +59,15 @@ module SimpleTokenAuthentication
     end
 
     def find_record_from_identifier(entity)
-      email = entity.get_identifier_from_params_or_headers(self).presence
+      identifier = entity.get_identifier_from_params_or_headers(self).presence
 
       # Rails 3 and 4 finder methods are supported,
       # see https://github.com/ryanb/cancan/blob/1.6.10/lib/cancan/controller_resource.rb#L108-L111
       record = nil
       if entity.model.respond_to? "find_by"
-        record = email && entity.model.find_by(email: email)
-      elsif entity.model.respond_to? "find_by_email"
-        record = email && entity.model.find_by_email(email)
+        record = identifier && entity.model.find_by(entity.identifier_field_name => identifier)
+      else
+        record = identifier && entity.model.where(entity.identifier_field_name => identifier).limit(1).first
       end
     end
 

--- a/lib/simple_token_authentication/entity.rb
+++ b/lib/simple_token_authentication/entity.rb
@@ -49,8 +49,17 @@ module SimpleTokenAuthentication
       "#{name_underscore}_token".to_sym
     end
 
+    def identifier
+      if (SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym].presence && \
+         SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier_field].presence)
+        SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier_field]
+      else
+        :email
+      end
+    end
+
     def identifier_param_name
-      "#{name_underscore}_#{identifier_field_name}".to_sym
+      "#{name_underscore}_#{identifier}".to_sym
     end
 
     def get_token_from_params_or_headers controller

--- a/lib/simple_token_authentication/entity.rb
+++ b/lib/simple_token_authentication/entity.rb
@@ -17,6 +17,16 @@ module SimpleTokenAuthentication
       name.underscore
     end
 
+    def identifier_field_name
+
+      if SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier_field]
+        return SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier].to_sym
+      else
+        # Fallback for older configurations, when email was the only possible identifier. 
+        return :email
+      end
+    end
+
     # Private: Return the name of the header to watch for the token authentication param
     def token_header_name
       if SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym].presence
@@ -29,7 +39,7 @@ module SimpleTokenAuthentication
     # Private: Return the name of the header to watch for the email param
     def identifier_header_name
       if SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym].presence
-        SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:email]
+        SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][identifier_field_name]
       else
         "X-#{name}-Email"
       end
@@ -40,7 +50,7 @@ module SimpleTokenAuthentication
     end
 
     def identifier_param_name
-      "#{name_underscore}_email".to_sym
+      "#{name_underscore}_identifier".to_sym
     end
 
     def get_token_from_params_or_headers controller
@@ -53,8 +63,8 @@ module SimpleTokenAuthentication
 
     def get_identifier_from_params_or_headers controller
       # if the identifier (email) is not present among params, get it from headers
-      if email = controller.params[identifier_param_name].blank? && controller.request.headers[identifier_header_name]
-        controller.params[identifier_param_name] = email
+      if identifier = controller.params[identifier_param_name].blank? && controller.request.headers[identifier_header_name]
+        controller.params[identifier_param_name] = identifier
       end
       controller.params[identifier_param_name]
     end

--- a/lib/simple_token_authentication/entity.rb
+++ b/lib/simple_token_authentication/entity.rb
@@ -20,7 +20,7 @@ module SimpleTokenAuthentication
     def identifier_field_name
 
       if SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym] && SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier_field]
-        return SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier].to_sym
+        return SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier_field].to_sym
       else
         # Fallback for older configurations, when email was the only possible identifier. 
         return :email

--- a/lib/simple_token_authentication/entity.rb
+++ b/lib/simple_token_authentication/entity.rb
@@ -19,7 +19,7 @@ module SimpleTokenAuthentication
 
     def identifier_field_name
 
-      if SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier_field]
+      if SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym] && SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier_field]
         return SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier].to_sym
       else
         # Fallback for older configurations, when email was the only possible identifier. 
@@ -50,7 +50,7 @@ module SimpleTokenAuthentication
     end
 
     def identifier_param_name
-      "#{name_underscore}_identifier".to_sym
+      "#{name_underscore}_#{identifier_field_name}".to_sym
     end
 
     def get_token_from_params_or_headers controller

--- a/lib/simple_token_authentication/entity.rb
+++ b/lib/simple_token_authentication/entity.rb
@@ -32,7 +32,7 @@ module SimpleTokenAuthentication
       if SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym].presence
         if SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:email].presence
           return SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:email]
-        elsif SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier_field_name].presence && \
+        elsif SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier_field].presence && \
               SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier].presence
           return SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:identifier]
         else

--- a/spec/lib/simple_token_authentication/entity_spec.rb
+++ b/spec/lib/simple_token_authentication/entity_spec.rb
@@ -30,10 +30,6 @@ describe SimpleTokenAuthentication::Entity do
     expect(@subject).to respond_to :identifier_field_name
   end
 
-  it 'responds to :identifier', protected: true do
-    expect(@subject).to respond_to :identifier
-  end
-
   it 'responds to :identifier_header_name', protected: true do
     expect(@subject).to respond_to :identifier_header_name
   end
@@ -74,9 +70,9 @@ describe SimpleTokenAuthentication::Entity do
     end
   end
 
-  describe '#identifier', protected: true do
+  describe '#identifier_field_name', protected: true do
     it 'is a symbol' do
-      expect(@subject.identifier).to be_instance_of Symbol
+      expect(@subject.identifier_field_name).to be_instance_of Symbol
       
     end
 
@@ -97,7 +93,7 @@ describe SimpleTokenAuthentication::Entity do
             config.header_names = header_names
           end
           
-          expect(@subject.identifier).to eq :email
+          expect(@subject.identifier_field_name).to eq :email
           
           SimpleTokenAuthentication.configure do |config|
             config.header_names = default_header_names
@@ -113,7 +109,7 @@ describe SimpleTokenAuthentication::Entity do
             config.header_names = header_names
           end
           
-          expect(@subject.identifier).to eq :uuid
+          expect(@subject.identifier_field_name).to eq :uuid
           
           SimpleTokenAuthentication.configure do |config|
             config.header_names = default_header_names
@@ -130,34 +126,6 @@ describe SimpleTokenAuthentication::Entity do
 
     it 'defines a non-standard header field' do
       expect(@subject.token_header_name[0..1]).to eq 'X-'
-    end
-  end
-
-  describe '#identifier_field_name', protected: true do
-    default_header_names = SimpleTokenAuthentication.header_names
-    let(:header_names) {{super_user: { authentication_token: 'X-SuperUser-Token', identifier_field: :uuid, identifier: 'X-User-Login' }}}
-    
-    it 'is a Symbol' do
-      expect(@subject.identifier_field_name).to be_instance_of Symbol
-    end
-
-    context "when there is an identifier field name present in :header_names configuration" do
-      
-      before(:each) do
-        SimpleTokenAuthentication.configure do |config|
-          config.header_names = header_names
-        end
-      end
-
-      after(:each) do
-        SimpleTokenAuthentication.configure do |config|
-          config.header_names = default_header_names
-        end
-      end
-      
-      it "returns the field name" do
-        expect(@subject.identifier_field_name).to eq :uuid
-      end
     end
   end
 

--- a/spec/lib/simple_token_authentication/entity_spec.rb
+++ b/spec/lib/simple_token_authentication/entity_spec.rb
@@ -26,6 +26,14 @@ describe SimpleTokenAuthentication::Entity do
     expect(@subject).to respond_to :token_header_name
   end
 
+  it 'responds to :identifier_field_name', protected: true do
+    expect(@subject).to respond_to :identifier_field_name
+  end
+
+  it 'responds to :identifier', protected: true do
+    expect(@subject).to respond_to :identifier
+  end
+
   it 'responds to :identifier_header_name', protected: true do
     expect(@subject).to respond_to :identifier_header_name
   end
@@ -122,6 +130,34 @@ describe SimpleTokenAuthentication::Entity do
 
     it 'defines a non-standard header field' do
       expect(@subject.token_header_name[0..1]).to eq 'X-'
+    end
+  end
+
+  describe '#identifier_field_name', protected: true do
+    default_header_names = SimpleTokenAuthentication.header_names
+    let(:header_names) {{super_user: { authentication_token: 'X-SuperUser-Token', identifier_field: :uuid, identifier: 'X-User-Login' }}}
+    
+    it 'is a Symbol' do
+      expect(@subject.identifier_field_name).to be_instance_of Symbol
+    end
+
+    context "when there is an identifier field name present in :header_names configuration" do
+      
+      before(:each) do
+        SimpleTokenAuthentication.configure do |config|
+          config.header_names = header_names
+        end
+      end
+
+      after(:each) do
+        SimpleTokenAuthentication.configure do |config|
+          config.header_names = default_header_names
+        end
+      end
+      
+      it "returns the field name" do
+        expect(@subject.identifier_field_name).to eq :uuid
+      end
     end
   end
 

--- a/spec/lib/simple_token_authentication/entity_spec.rb
+++ b/spec/lib/simple_token_authentication/entity_spec.rb
@@ -66,6 +66,55 @@ describe SimpleTokenAuthentication::Entity do
     end
   end
 
+  describe '#identifier', protected: true do
+    it 'is a symbol' do
+      expect(@subject.identifier).to be_instance_of Symbol
+      
+    end
+
+    context "when there is a configuration for header_names provided" do
+      default_header_names = SimpleTokenAuthentication.header_names
+
+      after(:each) do
+        SimpleTokenAuthentication.configure do |config|
+          config.header_names = default_header_names
+        end
+      end
+      
+      context "and it still uses the old :email symbol" do
+        let(:header_names) {{super_user: { authentication_token: 'X-SuperUser-Token', email: 'X-SuperUser-Email' }}}
+  
+        it 'is :email' do
+          SimpleTokenAuthentication.configure do |config|
+            config.header_names = header_names
+          end
+          
+          expect(@subject.identifier).to eq :email
+          
+          SimpleTokenAuthentication.configure do |config|
+            config.header_names = default_header_names
+          end
+        end
+      end
+
+      context "and it explicitly sets an :identifier_field different" do
+        let(:header_names) {{ super_user: { authentication_token: 'X-SuperUser-Token', identifier_field: :uuid, identifier: 'X-SuperUser-Login' }}}
+      
+        it 'is :email' do
+          SimpleTokenAuthentication.configure do |config|
+            config.header_names = header_names
+          end
+          
+          expect(@subject.identifier).to eq :uuid
+          
+          SimpleTokenAuthentication.configure do |config|
+            config.header_names = default_header_names
+          end
+        end
+      end
+    end
+  end
+
   describe '#token_header_name', protected: true do
     it 'is a String' do
       expect(@subject.token_header_name).to be_instance_of String


### PR DESCRIPTION
Hi everybody,

Thank you for providing this Gem. It is a real pain killer. Unfortunately I ran into troubles when I did not have the email of a user. So I changed this gem for allowing other fields for identifying a model than only :email.

Please be so kind an consider this pull request.

# Scenario

- As a developer of mobile applications,
- when I want to realize token based authentication after a Facebook login
- and the user denied the provision of her email address
- then I still want to be able to use token based authentication but using a model field that is different from "email".
- Further, old configurations of simple_token_authentication should still work as before.

# The solution in this pull request

I changed the format for header_names. It now provides the options `identifier_field` and `identifier`, where `identifier` holds the HTTP-Header-Name that shall be used for providing the identifier such as "X-User-Uuid". `identifier_name` holds a Symbol which tells which model field shall be used, such as ":email" or ":uuid".

Please feel free to contact me.


