### PR TITLE
Automatically downcase email when using Devise case-insensitive keys

### DIFF
--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -54,8 +54,8 @@ module SimpleTokenAuthentication
 
       # Rails 3 and 4 finder methods are supported,
       # see https://github.com/ryanb/cancan/blob/1.6.10/lib/cancan/controller_resource.rb#L108-L111
-      record = nil
-      record = email && entity.model.where(email: email).first
+      email.downcase! if email && Devise.case_insensitive_keys.include?(:email)
+      email && entity.model.where(email: email).first
     end
 
     def token_comparator


### PR DESCRIPTION
Devise can be configured to have 'case_insensitive_keys'. By default, the `email` field is one of them.

However, the finder in the TokenAuthenticationHandler does not take this setting into account when finding records. This causes users that have signed up with an uppercase character in their email not to be authenticated by their token.

I've browsed the specs, but could not find the best spot to make a change there. Sorry, but @gonzalo-bulnes will probably find that faster than myself :)
