### PR TITLE
More flexible configuration and adding a method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log
 test/dummy/tmp/
 test/dummy/.sass-cache
-
+.idea/*
 # Rubygems
 *.gem
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ SimpleTokenAuthentication.configure do |config|
   # If false, users must provide their authentication token and email at every request.
   # config.sign_in_token = false
 
+
+
+  #
+  # Set the record key to find a user. Default is :email
+  # config.record_key = :email
+  config.record_key = :username
+  #
+  #
+  # Set if the value for record key is case insensitive or not. Default is false.
+  # Example: abc@example.com != Abc@example.com
+  # when case_insensitive_key is set to false
+  #
+  # config.case_insensitive_key = false
+
+
+
   # Configure the name of the HTTP headers watched for authentication.
   #
   # Default header names for a given token authenticatable entity follow the pattern:
@@ -157,7 +173,15 @@ SimpleTokenAuthentication.configure do |config|
   #     `X-Admin-Auth-Token, X-SuperAdmin-Email`
   #
   # config.header_names = { user: { authentication_token: 'X-User-Token', email: 'X-User-Email' } }
-
+  #
+  #
+  #
+  # You can change header names the user key from email to username for example.
+  # Example: config.header_names = { user: { authentication_token: 'X-User-Token', username: 'X-User-Username' } }
+  #
+  #
+  #
+  #
   # Configure the Devise trackable strategy integration.
   #
   # If true, tracking is disabled for token authentication: signing in through
@@ -167,6 +191,7 @@ SimpleTokenAuthentication.configure do |config|
   # then signing in through token authentication will be tracked as any other sign in.
   #
   # config.skip_devise_trackable = true
+  #
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ Usage
 
 Assuming `user` is an instance of `User`, which is _token authenticatable_: each time `user` will be saved, and `user.authentication_token.blank?` it receives a new and unique authentication token (via `Devise.friendly_token`).
 
+NOTE:
+The gem adds a before_filter :ensure_authentication_token to ensure each record has a authentication token.
+
+You can also use "reset_authentication_token" method for a user object if you wish to regenerate the token in some specific scenario.
+
 ### Authentication Method 1: Query Params
 
 You can authenticate passing the `user_email` and `user_token` params as query params:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This gem packages the content of the gist.
 
   [josevalim]: https://github.com/josevalim
   [gonzalo-bulnes]: https://github.com/gonzalo-bulnes
-
+  
 Installation
 ------------
 
@@ -135,25 +135,21 @@ SimpleTokenAuthentication.configure do |config|
   # in other words, if the authentication token acts as a signin token.
   # If true, user is stored in the session and the authentication token and
   # email may be provided only once.
-  # If false, users must provide their authentication token and email at every request.
+  # If false, users must provide their authentication token and email or record_key (Eg: username) at every request.
   # config.sign_in_token = false
-
-
-
+  #
   #
   # Set the record key to find a user. Default is :email
   # config.record_key = :email
-  config.record_key = :username
   #
   #
   # Set if the value for record key is case insensitive or not. Default is false.
   # Example: abc@example.com != Abc@example.com
-  # when case_insensitive_key is set to false
-  #
+  #           when case_insensitive_key is set to false
   # config.case_insensitive_key = false
-
-
-
+  #
+  # 
+  # 
   # Configure the name of the HTTP headers watched for authentication.
   #
   # Default header names for a given token authenticatable entity follow the pattern:
@@ -174,10 +170,9 @@ SimpleTokenAuthentication.configure do |config|
   #
   # config.header_names = { user: { authentication_token: 'X-User-Token', email: 'X-User-Email' } }
   #
-  #
-  #
   # You can change header names the user key from email to username for example.
-  # Example: config.header_names = { user: { authentication_token: 'X-User-Token', username: 'X-User-Username' } }
+  # Example: 
+  #    config.header_names = { user: { authentication_token: 'X-User-Token', username: 'X-User-Username' } }
   #
   #
   #

--- a/lib/simple_token_authentication/acts_as_token_authenticatable.rb
+++ b/lib/simple_token_authentication/acts_as_token_authenticatable.rb
@@ -24,6 +24,10 @@ module SimpleTokenAuthentication
       end
     end
 
+    def reset_authentication_token
+      self.authentication_token = generate_authentication_token(token_generator)
+    end
+
     def generate_authentication_token(token_generator)
       loop do
         token = token_generator.generate_token

--- a/lib/simple_token_authentication/configuration.rb
+++ b/lib/simple_token_authentication/configuration.rb
@@ -8,6 +8,8 @@ module SimpleTokenAuthentication
     mattr_accessor :model_adapters
     mattr_accessor :adapters_dependencies
     mattr_accessor :skip_devise_trackable
+    mattr_accessor :record_key
+    mattr_accessor :case_insensitive_key
 
     # Default configuration
     @@fallback = :devise
@@ -20,6 +22,8 @@ module SimpleTokenAuthentication
                                 'rails'         => 'ActionController::Base',
                                 'rails_api'     => 'ActionController::API' }
     @@skip_devise_trackable = true
+    @@record_key = :email
+    @@case_insensitive_key = :false
 
     # Allow the default configuration to be overwritten from initializers
     def configure

--- a/lib/simple_token_authentication/entity.rb
+++ b/lib/simple_token_authentication/entity.rb
@@ -3,6 +3,7 @@ module SimpleTokenAuthentication
     def initialize model
       @model = model
       @name = model.name
+      @model_key = SimpleTokenAuthentication.record_key || :email
     end
 
     def model
@@ -30,7 +31,7 @@ module SimpleTokenAuthentication
     # Private: Return the name of the header to watch for the email param
     def identifier_header_name
       if SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym].presence \
-        && identifier_header_name = SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:email]
+        && identifier_header_name = SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][@model_key]
         identifier_header_name
       else
         "X-#{name}-Email"
@@ -42,7 +43,7 @@ module SimpleTokenAuthentication
     end
 
     def identifier_param_name
-      "#{name_underscore}_email".to_sym
+      "#{name_underscore}_#{@model_key.to_s}".to_sym
     end
 
     def get_token_from_params_or_headers controller
@@ -54,9 +55,9 @@ module SimpleTokenAuthentication
     end
 
     def get_identifier_from_params_or_headers controller
-      # if the identifier (email) is not present among params, get it from headers
-      if email = controller.params[identifier_param_name].blank? && controller.request.headers[identifier_header_name]
-        controller.params[identifier_param_name] = email
+      # if the identifier (email | model key) is not present among params, get it from headers
+      if model_key = controller.params[identifier_param_name].blank? && controller.request.headers[identifier_header_name]
+        controller.params[identifier_param_name] = model_key
       end
       controller.params[identifier_param_name]
     end

--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -52,14 +52,15 @@ module SimpleTokenAuthentication
     end
 
     def find_record_from_identifier(entity)
-      email = entity.get_identifier_from_params_or_headers(self).presence
+      model_key = SimpleTokenAuthentication.record_key
+      record_identity_value = entity.get_identifier_from_params_or_headers(self).presence
 
-      email = integrate_with_devise_case_insensitive_keys(email)
+      record_identity_value = integrate_with_devise_case_insensitive_keys(record_identity_value)
 
       # The finder method should be compatible with all the model adapters,
       # namely ActiveRecord and Mongoid in all their supported versions.
       record = nil
-      record = email && entity.model.where(email: email).first
+      record = record_identity_value && entity.model.where("#{model_key} = #{record_identity_value}").first
     end
 
     # Private: Take benefit from Devise case-insensitive keys
@@ -69,9 +70,9 @@ module SimpleTokenAuthentication
     # email - the original email String
     #
     # Returns an email String which case follows the Devise case-insensitive keys policy
-    def integrate_with_devise_case_insensitive_keys(email)
-      email.downcase! if email && Devise.case_insensitive_keys.include?(:email)
-      email
+    def integrate_with_devise_case_insensitive_keys(model_identifier)
+      model_identifier.downcase! if model_identifier && SimpleTokenAuthentication.case_insensitive_key && Devise.case_insensitive_keys.include?(SimpleTokenAuthentication.record_key)
+      model_identifier
     end
 
     # Private: Get one (always the same) object which behaves as a token comprator


### PR DESCRIPTION
The gem was tied with `:email` as the user identifier. Which meant, someone using devise for authentication cannot use this gem for token authentication if their user model has `username` as the attribute in place of `email`.

In this pull-request I've made this key configurable keepinig `:email` as default.

Also, the "email" attribute was by default considered as case insensitive. I once again made it optional by making it configurable.

The gem adds a before_filter to ensure_authentication_token. But in some cases, for better security in case of token theft maybe, a developer may choose to reset the authentication token based on any event.

I've added a method `reset_authentication_token` which is now available for use. Note: The before_save filter remains the same as before - ensure_authentication_token.

Have updated the readme with the above mentioned changes.
- Vishnu Narang
  (Let me know if you need any clarification)
