### PR TITLE
Support namespaced devise models

### DIFF
--- a/lib/simple_token_authentication/entity.rb
+++ b/lib/simple_token_authentication/entity.rb
@@ -14,7 +14,7 @@ module SimpleTokenAuthentication
     end
 
     def name_underscore
-      name.underscore
+      name.underscore.gsub("/", "_")
     end
 
     # Private: Return the name of the header to watch for the token authentication param

--- a/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
+++ b/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
@@ -347,5 +347,58 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
         end
       end
     end
+
+    # Namespaced::User
+
+    context 'and which handles token authentication for Namespaced::User' do
+
+      before(:each) do
+        double_namespaced_user_model
+      end
+
+      it 'ensures its instances require namespaced_user to authenticate from token or any Devise strategy before any action', public: true do
+        expect(subject).to receive(:before_filter).with(:authenticate_namespaced_user_from_token!, {})
+        subject.handle_token_authentication_for Namespaced::User
+      end
+
+      context 'and disables the fallback to Devise authentication' do
+
+        let(:options) do
+          { fallback_to_devise: false }
+        end
+
+        it 'ensures its instances require namespaced_user to authenticate from token before any action', public: true do
+          expect(subject).to receive(:before_filter).with(:authenticate_namespaced_user_from_token, {})
+          subject.handle_token_authentication_for Namespaced::User, options
+        end
+      end
+
+      describe 'instance' do
+
+        before(:each) do
+          double_namespaced_user_model
+
+          subject.class_eval do
+            handle_token_authentication_for Namespaced::User
+          end
+        end
+
+        it 'responds to :authenticate_namespaced_user_from_token', protected: true do
+          expect(subject.new).to respond_to :authenticate_namespaced_user_from_token
+        end
+
+        it 'responds to :authenticate_namespaced_user_from_token!', protected: true do
+          expect(subject.new).to respond_to :authenticate_namespaced_user_from_token!
+        end
+
+        it 'does not respond to :authenticate_user_from_token', protected: true do
+          expect(subject.new).not_to respond_to :authenticate_user_from_token
+        end
+
+        it 'does not respond to :authenticate_user_from_token!', protected: true do
+          expect(subject.new).not_to respond_to :authenticate_user_from_token!
+        end
+      end
+    end
   end
 end

--- a/spec/support/dummy_classes_helper.rb
+++ b/spec/support/dummy_classes_helper.rb
@@ -78,3 +78,9 @@ def double_super_admin_model
   stub_const('SuperAdmin', super_admin)
   allow(super_admin).to receive(:name).and_return('SuperAdmin')
 end
+
+def double_namespaced_user_model
+  namespaced_user = double()
+  stub_const('Namespaced::User', namespaced_user)
+  allow(namespaced_user).to receive(:name).and_return('Namespaced::User')
+end


### PR DESCRIPTION
Currently, any named spaced classes will have there `name_underscore` translated incorrectly:
```
Namespaced::User.name_underscore   #=> namespaced/user
```

This commit fixes that behavior (with specs) to be:
```
Namespaced::User.name_underscore   #=> namespaced_user
```