### PR TITLE
Changed token authentication handler to use find_for_database_authentication

### DIFF
--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -60,7 +60,7 @@ module SimpleTokenAuthentication
       # The finder method should be compatible with all the model adapters,
       # namely ActiveRecord and Mongoid in all their supported versions.
       record = nil
-      record = identifier_param_value && entity.model.where(entity.identifier => identifier_param_value).first
+      record = identifier_param_value && entity.model.find_for_database_authentication(entity.identifier => identifier_param_value)
     end
 
     # Private: Take benefit from Devise case-insensitive keys


### PR DESCRIPTION
This change is necessary to allow login by multiple identifiers. For example username and email after following this guide: https://github.com/plataformatec/devise/wiki/How-To:-Allow-users-to-sign-in-using-their-username-or-email-address#tell-devise-to-use-username-in-the-authentication_keys