### PR TITLE
Load resource first

### DIFF
--- a/lib/simple_token_authentication.rb
+++ b/lib/simple_token_authentication.rb
@@ -35,7 +35,7 @@ module SimpleTokenAuthentication
   def self.load_available_adapters adapters_short_names
     available_adapters = adapters_short_names.collect do |short_name|
       adapter_name = "simple_token_authentication/adapters/#{short_name}_adapter"
-      if adapter_dependency_fulfilled?(short_name) && require(adapter_name)
+      if require(adapter_name) && adapter_dependency_fulfilled?(short_name)
         adapter_name.camelize.constantize
       end
     end


### PR DESCRIPTION
When we use `simple_token_authentication` with `mongoid` we have an error `SimpleTokenAuthentication::NoAdapterAvailableError` because we try to looking for `::Mongoid::Document` before loading it.

```
Error starting application
Your Rack app raised an exception when Pow tried to run it.
SimpleTokenAuthentication::NoAdapterAvailableError: SimpleTokenAuthentication::NoAdapterAvailableError
~/.rvm/gems/ruby-2.2.3@auriga/gems/simple_token_authentication-1.10.0/lib/simple_token_authentication.rb:48:in `load_available_adapters'
~/.rvm/gems/ruby-2.2.3@auriga/gems/simple_token_authentication-1.10.0/lib/simple_token_authentication.rb:57:in `<module:SimpleTokenAuthentication>'
~/.rvm/gems/ruby-2.2.3@auriga/gems/simple_token_authentication-1.10.0/lib/simple_token_authentication.rb:5:in `<top (required)>'
~/.rvm/gems/ruby-2.2.3@global/gems/bundler-1.10.6/lib/bundler/runtime.rb:76:in `require'
~/.rvm/gems/ruby-2.2.3@global/gems/bundler-1.10.6/lib/bundler/runtime.rb:76:in `block (2 levels) in require'
~/.rvm/gems/ruby-2.2.3@global/gems/bundler-1.10.6/lib/bundler/runtime.rb:72:in `each'
~/.rvm/gems/ruby-2.2.3@global/gems/bundler-1.10.6/lib/bundler/runtime.rb:72:in `block in require'
~/.rvm/gems/ruby-2.2.3@global/gems/bundler-1.10.6/lib/bundler/runtime.rb:61:in `each'
~/.rvm/gems/ruby-2.2.3@global/gems/bundler-1.10.6/lib/bundler/runtime.rb:61:in `require'
~/.rvm/gems/ruby-2.2.3@global/gems/bundler-1.10.6/lib/bundler.rb:134:in `require'
~/WorkSpace/Actives/auriga/config/application.rb:16:in `<top (required)>'
~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
~/WorkSpace/Actives/auriga/config/environment.rb:2:in `<top (required)>'
~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
~/.rvm/rubies/ruby-2.2.3/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
~/WorkSpace/Actives/auriga/config.ru:3:in `block in <main>'
~/Library/Application Support/Pow/Versions/0.5.0/node_modules/nack/lib/nack/builder.rb:4:in `instance_eval'
~/Library/Application Support/Pow/Versions/0.5.0/node_modules/nack/lib/nack/builder.rb:4:in `initialize'
~/WorkSpace/Actives/auriga/config.ru:1:in `new'
~/WorkSpace/Actives/auriga/config.ru:1:in `<main>'
~/Library/Application Support/Pow/Versions/0.5.0/node_modules/nack/lib/nack/server.rb:51:in `eval'
~/Library/Application Support/Pow/Versions/0.5.0/node_modules/nack/lib/nack/server.rb:51:in `load_config'
~/Library/Application Support/Pow/Versions/0.5.0/node_modules/nack/lib/nack/server.rb:42:in `initialize'
~/Library/Application Support/Pow/Versions/0.5.0/node_modules/nack/lib/nack/server.rb:12:in `new'
~/Library/Application Support/Pow/Versions/0.5.0/node_modules/nack/lib/nack/server.rb:12:in `run'
~/Library/Application Support/Pow/Versions/0.5.0/node_modules/nack/bin/nack_worker:4:in `<main>'
```