### PR TITLE
Use the Devise entity condition finder over directly using `where`.

### DIFF
--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -59,8 +59,7 @@ module SimpleTokenAuthentication
 
       # The finder method should be compatible with all the model adapters,
       # namely ActiveRecord and Mongoid in all their supported versions.
-      record = nil
-      record = identifier_param_value && entity.model.where(entity.identifier => identifier_param_value).first
+      identifier_param_value && entity.model.find_first_by_auth_conditions(entity.identifier => identifier_param_value)
     end
 
     # Private: Take benefit from Devise case-insensitive keys

--- a/spec/configuration/header_names_option_spec.rb
+++ b/spec/configuration/header_names_option_spec.rb
@@ -24,14 +24,14 @@ describe 'Simple Token Authentication' do
         # given one *c*orrect record (which is supposed to get signed in)
         @charles_record = double()
         [user, admin].each do |model|
-          allow(model).to receive(:where).with(email: 'charles@example.com').and_return([@charles_record])
+          allow(model).to receive(:find_first_by_auth_conditions).with(email: 'charles@example.com').and_return(@charles_record)
         end
         allow(@charles_record).to receive(:authentication_token).and_return('ch4rlEs_toKeN')
 
         # and one *w*rong record (which should not be signed in)
         @waldo_record = double()
         [user, admin].each do |model|
-          allow(model).to receive(:where).with(email: 'waldo@example.com').and_return([@waldo_record])
+          allow(model).to receive(:find_first_by_auth_conditions).with(email: 'waldo@example.com').and_return(@waldo_record)
         end
         allow(@waldo_record).to receive(:authentication_token).and_return('w4LdO_toKeN')
 
@@ -401,12 +401,12 @@ describe 'Simple Token Authentication' do
 
       # given one *c*orrect record (which is supposed to get signed in)
       @charles_record = double()
-      allow(user).to receive(:where).with(email: 'charles@example.com').and_return([@charles_record])
+      allow(user).to receive(:find_first_by_auth_conditions).with(email: 'charles@example.com').and_return(@charles_record)
       allow(@charles_record).to receive(:authentication_token).and_return('ch4rlEs_toKeN')
 
       # and one *w*rong record (which should not be signed in)
       @waldo_record = double()
-      allow(user).to receive(:where).with(email: 'waldo@example.com').and_return([@waldo_record])
+      allow(user).to receive(:find_first_by_auth_conditions).with(email: 'waldo@example.com').and_return(@waldo_record)
       allow(@waldo_record).to receive(:authentication_token).and_return('w4LdO_toKeN')
 
       # given a controller class which acts as token authentication handler

--- a/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
+++ b/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
@@ -213,8 +213,9 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
         it 'returns the proper record if any' do
           # let's say there is a record
           record = double()
-          allow(@entity).to receive_message_chain(:model, :where).with(email: 'alice@example.com')
-          .and_return([record])
+          allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+          .with(email: 'alice@example.com')
+          .and_return(record)
 
           expect(subject.new.send(:find_record_from_identifier, @entity)).to eq record
         end
@@ -231,11 +232,13 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
           # let's say there is a record...
           record = double()
           # ...whose identifier is downcased...
-          allow(@entity).to receive_message_chain(:model, :where).with(email: 'alice@example.com')
-          .and_return([record])
+          allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+          .with(email: 'alice@example.com')
+          .and_return(record)
           # ...not upcased
-          allow(@entity).to receive_message_chain(:model, :where).with(email: 'AliCe@ExampLe.Com')
-          .and_return([])
+          allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+          .with(email: 'AliCe@ExampLe.Com')
+          .and_return(nil)
 
           expect(subject.new.send(:find_record_from_identifier, @entity)).to be_nil
         end
@@ -259,8 +262,9 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
         it 'returns the proper record if any' do
           # let's say there is a record
           record = double()
-          allow(@entity).to receive_message_chain(:model, :where).with(email: 'alice@example.com')
-          .and_return([record])
+          allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+          .with(email: 'alice@example.com')
+          .and_return(record)
 
           expect(subject.new.send(:find_record_from_identifier, @entity)).to eq record
         end
@@ -277,12 +281,13 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
           # let's say there is a record...
           record = double()
           # ...whose identifier is downcased...
-          allow(@entity).to receive_message_chain(:model, :where)
-          allow(@entity).to receive_message_chain(:model, :where).with(email: 'alice@example.com')
-          .and_return([record])
+          allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+          allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+          .with(email: 'alice@example.com')
+          .and_return(record)
           # ...not upcased
-          allow(@entity).to receive_message_chain(:model, :where).with(email: 'AliCe@ExampLe.Com')
-          .and_return([])
+          allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions).with(email: 'AliCe@ExampLe.Com')
+          .and_return(nil)
 
           expect(subject.new.send(:find_record_from_identifier, @entity)).to eq record
         end
@@ -312,8 +317,9 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
           it 'returns the proper record if any' do
             # let's say there is a record
             record = double()
-            allow(@entity).to receive_message_chain(:model, :where).with(phone_number: 'alice@example.com')
-            .and_return([record])
+            allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+            .with(phone_number: 'alice@example.com')
+            .and_return(record)
 
             expect(subject.new.send(:find_record_from_identifier, @entity)).to eq record
           end
@@ -330,11 +336,13 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
             # let's say there is a record...
             record = double()
             # ...whose identifier is downcased...
-            allow(@entity).to receive_message_chain(:model, :where).with(phone_number: 'alice@example.com')
-            .and_return([record])
+            allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+            .with(phone_number: 'alice@example.com')
+            .and_return(record)
             # ...not upcased
-            allow(@entity).to receive_message_chain(:model, :where).with(phone_number: 'AliCe@ExampLe.Com')
-            .and_return([])
+            allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+            .with(phone_number: 'AliCe@ExampLe.Com')
+            .and_return(nil)
 
             expect(subject.new.send(:find_record_from_identifier, @entity)).to be_nil
           end
@@ -358,8 +366,9 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
           it 'returns the proper record if any' do
             # let's say there is a record
             record = double()
-            allow(@entity).to receive_message_chain(:model, :where).with(phone_number: 'alice@example.com')
-            .and_return([record])
+            allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+            .with(phone_number: 'alice@example.com')
+            .and_return(record)
 
             expect(subject.new.send(:find_record_from_identifier, @entity)).to eq record
           end
@@ -376,12 +385,14 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
             # let's say there is a record...
             record = double()
             # ...whose identifier is downcased...
-            allow(@entity).to receive_message_chain(:model, :where)
-            allow(@entity).to receive_message_chain(:model, :where).with(phone_number: 'alice@example.com')
-            .and_return([record])
+            allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+            allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+            .with(phone_number: 'alice@example.com')
+            .and_return(record)
             # ...not upcased
-            allow(@entity).to receive_message_chain(:model, :where).with(phone_number: 'AliCe@ExampLe.Com')
-            .and_return([])
+            allow(@entity).to receive_message_chain(:model, :find_first_by_auth_conditions)
+            .with(phone_number: 'AliCe@ExampLe.Com')
+            .and_return(nil)
 
             expect(subject.new.send(:find_record_from_identifier, @entity)).to eq record
           end


### PR DESCRIPTION
Sometimes the Devise finder is overridden (in my case, that's because the `email` column was replaced with an association) so directly using `where` will cause this to fail.