### PR TITLE
Move configuration for identifier and token retrieval to the controller.

### DIFF
--- a/lib/simple_token_authentication/entity.rb
+++ b/lib/simple_token_authentication/entity.rb
@@ -18,56 +18,12 @@ module SimpleTokenAuthentication
       @name_underscore || name.underscore
     end
 
-    # Private: Return the name of the header to watch for the token authentication param
-    def token_header_name
-      if SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym].presence \
-        && token_header_name = SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][:authentication_token]
-        token_header_name
-      else
-        "X-#{name_underscore.camelize}-Token"
-      end
-    end
-
-    # Private: Return the name of the header to watch for the email param
-    def identifier_header_name
-      if SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym].presence \
-        && identifier_header_name = SimpleTokenAuthentication.header_names["#{name_underscore}".to_sym][identifier]
-        identifier_header_name
-      else
-        "X-#{name_underscore.camelize}-#{identifier.to_s.camelize}"
-      end
-    end
-
-    def token_param_name
-      "#{name_underscore}_token".to_sym
-    end
-
-    def identifier_param_name
-      "#{name_underscore}_#{identifier}".to_sym
-    end
-
     def identifier
       if custom_identifier = SimpleTokenAuthentication.identifiers["#{name_underscore}".to_sym]
         custom_identifier.to_sym
       else
         :email
       end
-    end
-
-    def get_token_from_params_or_headers controller
-      # if the token is not present among params, get it from headers
-      if token = controller.params[token_param_name].blank? && controller.request.headers[token_header_name]
-        controller.params[token_param_name] = token
-      end
-      controller.params[token_param_name]
-    end
-
-    def get_identifier_from_params_or_headers controller
-      # if the identifier is not present among params, get it from headers
-      if identifer_param = controller.params[identifier_param_name].blank? && controller.request.headers[identifier_header_name]
-        controller.params[identifier_param_name] = identifer_param
-      end
-      controller.params[identifier_param_name]
     end
   end
 end

--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -27,10 +27,11 @@ module SimpleTokenAuthentication
       private :integrate_with_devise_case_insensitive_keys
     end
 
-    def authenticate_entity_from_token!(entity)
-      record = find_record_from_identifier(entity)
+    def authenticate_entity_from_token!(entity, search_options)
+      identifier, token = search_parameters(search_options)
+      record = find_record_from_identifier(entity, identifier)
 
-      if token_correct?(record, entity, token_comparator)
+      if token_correct?(record, token, token_comparator)
         perform_sign_in!(record, sign_in_handler)
       end
     end
@@ -39,9 +40,8 @@ module SimpleTokenAuthentication
       fallback_handler.fallback!(self, entity)
     end
 
-    def token_correct?(record, entity, token_comparator)
-      record && token_comparator.compare(record.authentication_token,
-                                         entity.get_token_from_params_or_headers(self))
+    def token_correct?(record, token, token_comparator)
+      record && token_comparator.compare(record.authentication_token, token)
     end
 
     def perform_sign_in!(record, sign_in_handler)
@@ -52,14 +52,32 @@ module SimpleTokenAuthentication
       sign_in_handler.sign_in self, record, store: SimpleTokenAuthentication.sign_in_token
     end
 
-    def find_record_from_identifier(entity)
-      identifier_param_value = entity.get_identifier_from_params_or_headers(self).presence
+    def search_parameters(search_options)
+      if search_options[:headers]
+        parameters = retrieve_parameters(request.headers, search_options[:headers][:identifier],
+                                         search_options[:headers][:token])
+        return parameters if parameters
+      end
+      if search_options[:params]
+        retrieve_parameters(params, search_options[:params][:identifer],
+                            search_options[:params][:token])
+      end
+    end
 
-      identifier_param_value = integrate_with_devise_case_insensitive_keys(identifier_param_value, entity)
+    def retrieve_parameters(object, identifier, token)
+      if object[identifier].present? && object[token].present?
+        [object[identifier], object[token]]
+      else
+        nil
+      end
+    end
+
+    def find_record_from_identifier(entity, identifier)
+      identifier = integrate_with_devise_case_insensitive_keys(identifier, entity)
 
       # The finder method should be compatible with all the model adapters,
       # namely ActiveRecord and Mongoid in all their supported versions.
-      identifier_param_value && entity.model.find_for_authentication(entity.identifier => identifier_param_value)
+      identifier && entity.model.find_for_authentication(entity.identifier => identifier)
     end
 
     # Private: Take benefit from Devise case-insensitive keys
@@ -95,7 +113,8 @@ module SimpleTokenAuthentication
         model_alias = options[:as] || options['as']
         entity = entities_manager.find_or_create_entity(model, model_alias)
         options = SimpleTokenAuthentication.parse_options(options)
-        define_token_authentication_helpers_for(entity, fallback_handler(options))
+        define_token_authentication_helpers_for(entity, search_options(entity, options),
+                                                fallback_handler(options))
         set_token_authentication_hooks(entity, options)
       end
 
@@ -106,6 +125,21 @@ module SimpleTokenAuthentication
         else
           class_variable_set(:@@entities_manager, EntitiesManager.new)
         end
+      end
+
+      # Private: Gets the options for finding the identifier and token for the current controller.
+      def search_options(entity, options)
+        default_options = {
+          params: {
+            identifier: "#{entity.name_underscore}_#{entity.identifier}".to_sym,
+            token: "#{entity.name_underscore}_token".to_sym,
+          },
+          headers: {
+            identifier: "X-#{entity.name_underscore.camelize}-#{entity.identifier.to_s.camelize}",
+            token: "X-#{entity.name_underscore.camelize}-Token"
+          }
+        }
+        (options[:search] || {}).reverse_merge(default_options)
       end
 
       # Private: Get one (always the same) object which behaves as a fallback authentication handler
@@ -121,21 +155,19 @@ module SimpleTokenAuthentication
         end
       end
 
-      def define_token_authentication_helpers_for(entity, fallback_handler)
+      def define_token_authentication_helpers_for(entity, search_options, fallback_handler)
 
         method_name = "authenticate_#{entity.name_underscore}_from_token"
         method_name_bang = method_name + '!'
 
         class_eval do
           define_method method_name.to_sym do
-            lambda { |_entity| authenticate_entity_from_token!(_entity) }.call(entity)
+            authenticate_entity_from_token!(entity, search_options)
           end
 
           define_method method_name_bang.to_sym do
-            lambda do |_entity|
-              authenticate_entity_from_token!(_entity)
-              fallback!(_entity, fallback_handler)
-            end.call(entity)
+            authenticate_entity_from_token!(entity, search_options)
+            fallback!(entity, fallback_handler)
           end
         end
       end


### PR DESCRIPTION
Addresses #207. I have not fixed the specs yet, because I'm not sure how the design will evolve.

This allows for a per-controller configuration of where identifiers and tokens should be searched. The idea is that there is clean separation between the model concerns from the controller concerns -- Entity seems to be very much closer to the model and should probably not interact with both the model and controller.

I am thinking of deprecating global configuration of which headers and which controller params to look up when deciding which entity to authenticate against. That makes the API inconsistent -- whoever is configuring the system needs to know how the model is translated to the entity name.

Here, instead of the global configuration, an extra configuration option `search_options` can be passed to `acts_as_token_authenticatable`:

```ruby
acts_as_token_authentication_handler_for(User, search_options: {
  headers: {
    identifier: 'x-user-email',
    token: 'token'
  },
  params: {
    identifier: 'user',
    token: 'token'
  }
})
```

This would search for `request.headers['x-user-email']`, and `request.headers['x-user-token']`, as well as `params['user']` and `params['token']`.

If you would like to disable any method,
```ruby
acts_as_token_authentication_handler_for(User, search_options: {
  headers: {
    identifier: 'x-user-email',
    token: 'token'
  },
  params: false # or nil
})
```
Then params will not be looked up. The search options in the PR currently default to the v1.11 names. Global configuration with overrides need to be manually changed to the new format.

I'm not entirely sure how many different uses for global configuration there are, so I'm not sure if there are edge cases I've not considered, but comments welcome.

@gonzalo-bulnes 64 specs break, I'm not sure how to fix all of them.
