### PR TITLE
Add Rails Metal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Finally define which controllers will handle token authentication (typ. `Applica
 # app/controllers/application_controller.rb
 
 class ApplicationController < ActionController::Base # or ActionController::API
+                                                     # or ActionController::Metal
   # ...
 
   acts_as_token_authentication_handler_for User

--- a/lib/simple_token_authentication/adapters/rails_metal_adapter.rb
+++ b/lib/simple_token_authentication/adapters/rails_metal_adapter.rb
@@ -1,0 +1,14 @@
+require 'action_controller'
+require 'simple_token_authentication/adapter'
+
+module SimpleTokenAuthentication
+  module Adapters
+    class RailsMetalAdapter
+      extend SimpleTokenAuthentication::Adapter
+
+      def self.base_class
+        ::ActionController::Metal
+      end
+    end
+  end
+end

--- a/lib/simple_token_authentication/configuration.rb
+++ b/lib/simple_token_authentication/configuration.rb
@@ -20,7 +20,8 @@ module SimpleTokenAuthentication
     @@adapters_dependencies = { 'active_record' => 'ActiveRecord::Base',
                                 'mongoid'       => 'Mongoid::Document',
                                 'rails'         => 'ActionController::Base',
-                                'rails_api'     => 'ActionController::API' }
+                                'rails_api'     => 'ActionController::API',
+                                'rails_metal'   => 'ActionController::Metal' }
     @@skip_devise_trackable = true
 
     # Allow the default configuration to be overwritten from initializers

--- a/lib/simple_token_authentication/configuration.rb
+++ b/lib/simple_token_authentication/configuration.rb
@@ -15,7 +15,7 @@ module SimpleTokenAuthentication
     @@header_names = {}
     @@identifiers = {}
     @@sign_in_token = false
-    @@controller_adapters = ['rails', 'rails_api']
+    @@controller_adapters = ['rails', 'rails_api', 'rails_metal']
     @@model_adapters = ['active_record', 'mongoid']
     @@adapters_dependencies = { 'active_record' => 'ActiveRecord::Base',
                                 'mongoid'       => 'Mongoid::Document',

--- a/spec/lib/simple_token_authentication/adapters/rails_metal_adapter_spec.rb
+++ b/spec/lib/simple_token_authentication/adapters/rails_metal_adapter_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'simple_token_authentication/adapters/rails_metal_adapter'
+
+describe 'SimpleTokenAuthentication::Adapters::RailsMetalAdapter' do
+
+  before(:each) do
+    stub_const('ActionController', Module.new)
+    stub_const('ActionController::Metal', double())
+
+    @subject = SimpleTokenAuthentication::Adapters::RailsMetalAdapter
+  end
+
+  it_behaves_like 'an adapter'
+
+  describe '.base_class' do
+
+    it 'is ActionController::Metal', private: true do
+      expect(@subject.base_class).to eq ActionController::Metal
+    end
+  end
+end

--- a/spec/lib/simple_token_authentication/configuration_spec.rb
+++ b/spec/lib/simple_token_authentication/configuration_spec.rb
@@ -20,8 +20,8 @@ describe SimpleTokenAuthentication::Configuration do
 
       it_behaves_like 'a configuration option', 'controller_adapters'
 
-      it "defauts to ['rails', 'rails_api']", private: true do
-        expect(@subject.controller_adapters).to eq ['rails', 'rails_api']
+      it "defauts to ['rails', 'rails_api', 'rails_metal']", private: true do
+        expect(@subject.controller_adapters).to eq ['rails', 'rails_api', 'rails_metal']
       end
     end
 

--- a/spec/lib/simple_token_authentication/configuration_spec.rb
+++ b/spec/lib/simple_token_authentication/configuration_spec.rb
@@ -43,6 +43,7 @@ describe SimpleTokenAuthentication::Configuration do
         expect(@subject.adapters_dependencies['mongoid']).to eq 'Mongoid::Document'
         expect(@subject.adapters_dependencies['rails']).to eq 'ActionController::Base'
         expect(@subject.adapters_dependencies['rails_api']).to eq 'ActionController::API'
+        expect(@subject.adapters_dependencies['rails_metal']).to eq 'ActionController::Metal'
       end
     end
 


### PR DESCRIPTION
**As an** API developer 
**In order to** write the fastest JSON APIs around 
**I want to** be able to use `ActionController::Metal` as my base API controller

Usage: see this [example application](https://github.com/singfoom/metal_simple_token_authentication_example)!
See #210