### PR TITLE
Improve migration suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ class User < ActiveRecord::Base
 end
 ```
 
-If the model or models you chose have no `:authentication_token` attribute, add them one (with an index):
+If the model or models you chose have no `:authentication_token` attribute, add them one (with a unique index):
 
 ```bash
-rails g migration add_authentication_token_to_users authentication_token:string:index
+rails g migration add_authentication_token_to_users "authentication_token:string{30}:uniq"
 rake db:migrate
 ```
 


### PR DESCRIPTION
Why not enforce it in the db since we're already checking for uniqueness? Also uniqueness check in the app can fail with concurrent requests (http://bit.ly/uniqueness-concurrency) - though unlikely in our situation since we are generating random strings rather than competing for a username.

Limiting string fields in the db is recommended for performance. Devise.friendly_token actually generates 20-char strings by default, but let's keep some redundant space for the future.