### PR TITLE
Update sign_in_handler.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 # Declare your gem's dependencies in simple_token_authentication.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
-gem 'devise', github: "plataformatec/devise"
 gemspec
 
 # Declare any dependencies that are still in development here instead of in

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 # Declare your gem's dependencies in simple_token_authentication.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
+gem 'devise', github: "plataformatec/devise"
 gemspec
 
 # Declare any dependencies that are still in development here instead of in

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: git://github.com/plataformatec/devise.git
+  revision: 2b3799e6ceb315172d14a16103ab9fb1702f79fc
+  specs:
+    devise (4.0.0.rc2)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0, < 5.1)
+      responders
+      warden (~> 1.2.3)
+
 PATH
   remote: .
   specs:
@@ -50,13 +61,6 @@ GEM
     builder (3.2.2)
     coderay (1.1.1)
     connection_pool (2.2.0)
-    devise (3.5.6)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
-      responders
-      thread_safe (~> 0.1)
-      warden (~> 1.2.3)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     globalid (0.3.6)
@@ -144,6 +148,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (>= 3.2.6, < 6)
+  devise!
   inch (~> 0.4)
   mime-types (< 3)
   mongoid (>= 3.1.0, < 5)

--- a/lib/simple_token_authentication/sign_in_handler.rb
+++ b/lib/simple_token_authentication/sign_in_handler.rb
@@ -13,7 +13,7 @@ module SimpleTokenAuthentication
     def integrate_with_devise_trackable!(controller)
       # Sign in using token should not be tracked by Devise trackable
       # See https://github.com/plataformatec/devise/issues/953
-      controller.env["devise.skip_trackable"] = SimpleTokenAuthentication.skip_devise_trackable
+      controller.request.env["devise.skip_trackable"] = SimpleTokenAuthentication.skip_devise_trackable
     end
   end
 end

--- a/spec/configuration/sign_in_token_option_spec.rb
+++ b/spec/configuration/sign_in_token_option_spec.rb
@@ -28,7 +28,9 @@ describe 'Simple Token Authentication' do
         # and both identifier and authentication token are correct
         allow(@controller).to receive(:find_record_from_identifier).and_return(@record)
         allow(@controller).to receive(:token_correct?).and_return(true)
-        allow(@controller).to receive(:env).and_return({})
+        request = double()
+        allow(request).to receive(:env).and_return({})
+        allow(@controller).to receive(:request).and_return(request)
       end
 
       context 'when false' do
@@ -80,8 +82,9 @@ describe 'Simple Token Authentication' do
       # and both identifier and authentication token are correct
       allow(@controller).to receive(:find_record_from_identifier).and_return(@record)
       allow(@controller).to receive(:token_correct?).and_return(true)
-      allow(@controller).to receive(:env).and_return({})
-
+      request = double()
+      allow(request).to receive(:env).and_return({})
+      allow(@controller).to receive(:request).and_return(request)
       # even if modified *after* the class was loaded
       allow(SimpleTokenAuthentication).to receive(:sign_in_token).and_return('updated value')
 

--- a/spec/configuration/skip_devise_trackable_option_spec.rb
+++ b/spec/configuration/skip_devise_trackable_option_spec.rb
@@ -27,7 +27,9 @@ describe SimpleTokenAuthentication do
         # and both identifier and authentication token are correct
         allow(@controller).to receive(:find_record_from_identifier).and_return(@record)
         allow(@controller).to receive(:token_correct?).and_return(true)
-        allow(@controller).to receive(:env).and_return({})
+        request = double()
+        allow(request).to receive(:env).and_return({})
+        allow(@controller).to receive(:request)
         allow(@controller).to receive(:sign_in)
       end
 
@@ -36,7 +38,7 @@ describe SimpleTokenAuthentication do
         it 'instructs Devise to track token-authentication-related signins' do
           allow(SimpleTokenAuthentication).to receive(:skip_devise_trackable).and_return(true)
 
-          expect(@controller).to receive_message_chain(:env, :[]=).with('devise.skip_trackable', true)
+          expect(@controller).to receive_message_chain(:request,:env, :[]=).with('devise.skip_trackable', true)
           @controller.authenticate_user_from_token
         end
       end
@@ -46,7 +48,7 @@ describe SimpleTokenAuthentication do
         it 'instructs Devise not to track token-authentication-related signins' do
           allow(SimpleTokenAuthentication).to receive(:skip_devise_trackable).and_return(false)
 
-          expect(@controller).to receive_message_chain(:env, :[]=).with('devise.skip_trackable', false)
+          expect(@controller).to receive_message_chain(:request,:env, :[]=).with('devise.skip_trackable', false)
           @controller.authenticate_user_from_token
         end
       end
@@ -80,7 +82,7 @@ describe SimpleTokenAuthentication do
       # and both identifier and authentication token are correct
       allow(@controller).to receive(:find_record_from_identifier).and_return(@record)
       allow(@controller).to receive(:token_correct?).and_return(true)
-      allow(@controller).to receive(:env).and_return({})
+      allow(@controller).to receive(:request).and_return({})
       allow(@controller).to receive(:sign_in)
 
       # even if modified *after* the class was loaded
@@ -88,7 +90,7 @@ describe SimpleTokenAuthentication do
 
       # the option updated value is taken into account
       # when token authentication is performed
-      expect(@controller).to receive_message_chain(:env, :[]=).with('devise.skip_trackable', 'updated value')
+      expect(@controller).to receive_message_chain(:request,:env, :[]=).with('devise.skip_trackable', 'updated value')
       @controller.authenticate_user_from_token
     end
   end

--- a/spec/lib/simple_token_authentication/sign_in_handler_spec.rb
+++ b/spec/lib/simple_token_authentication/sign_in_handler_spec.rb
@@ -8,8 +8,11 @@ describe SimpleTokenAuthentication::SignInHandler do
 
     it 'delegates sign in to Devise::Controllers::SignInOut#sign_in through a controller', private: true do
       controller = double()
+      env = double()
+      request = double()
+      allow(request).to receive(:env).and_return({})
+      allow(controller).to receive(:request).and_return(request)
       allow(controller).to receive(:sign_in).with(:record, option: 'some_value').and_return('Devise response.')
-      allow(controller).to receive(:env).and_return({})
 
       # delegating consists in sending the message
       expect(controller).to receive(:sign_in)
@@ -40,7 +43,9 @@ describe SimpleTokenAuthentication::SignInHandler do
       it 'ensures Devise trackable statistics are kept untouched', private: true do
         controller = double()
         env = double()
-        allow(controller).to receive(:env).and_return(env)
+        request = double()
+        allow(request).to receive(:env).and_return(env)
+        allow(controller).to receive(:request).and_return(request)
         expect(env).to receive(:[]=).with('devise.skip_trackable', true)
 
         subject.send :integrate_with_devise_trackable!, controller
@@ -57,7 +62,9 @@ describe SimpleTokenAuthentication::SignInHandler do
       it 'ensures Devise trackable statistics are updated', private: true do
         controller = double()
         env = double()
-        allow(controller).to receive(:env).and_return(env)
+        request = double()
+        allow(request).to receive(:env).and_return(env)
+        allow(controller).to receive(:request).and_return(request)
         expect(env).to receive(:[]=).with('devise.skip_trackable', false)
 
         subject.send :integrate_with_devise_trackable!, controller


### PR DESCRIPTION
As '.env' is deprecated in Rails 5.1, we have to use request.env

See #237 