### PR TITLE
Refactor de facto singletons as singletons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -260,11 +260,11 @@ This [gist][gist] did refactor the Jose Valim's code into an `ActiveSupport::Con
 [1.1.1]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.0.pre.5..v1.0.0
-[1.0.0.pre.5]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.0.beta.4..v1.0.0.pre.5
-[1.0.0.beta.4]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.0.beta.3..v1.0.0.beta.4
-[1.0.0.beta.3]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.0.beta.2..v1.0.0.beta.3
-[1.0.0.beta.2]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.0.beta..v1.0.0.beta.2
+[1.0.0]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.0.pre.5...v1.0.0
+[1.0.0.pre.5]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.0-beta.4...v1.0.0.pre.5
+[1.0.0-beta.4]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.0-beta.3...v1.0.0-beta.4
+[1.0.0-beta.3]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.0-beta.2...v1.0.0-beta.3
+[1.0.0-beta.2]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.0.0-beta...v1.0.0-beta.2
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simple Token Authentication
 
 Token authentication support has been removed from [Devise][devise] for security reasons. In [this gist][original-gist], Devise's [José Valim][josevalim] explains how token authentication should be performed in order to remain safe.
 
-This gem packages the content of the gist.
+This gem packages the content of the gist and provides a set of convenient options for increased flexibility.
 
   [devise]: https://github.com/plataformatec/devise
   [original-gist]: https://gist.github.com/josevalim/fb706b1e933ef01e4fb6

--- a/lib/simple_token_authentication/acts_as_token_authenticatable.rb
+++ b/lib/simple_token_authentication/acts_as_token_authenticatable.rb
@@ -35,9 +35,8 @@ module SimpleTokenAuthentication
       self.class.where(authentication_token: token).count == 0
     end
 
-    # Private: Get one (always the same) object which behaves as a token generator
     def token_generator
-      @token_generator ||= TokenGenerator.new
+      TokenGenerator.instance
     end
 
     module ClassMethods

--- a/lib/simple_token_authentication/devise_fallback_handler.rb
+++ b/lib/simple_token_authentication/devise_fallback_handler.rb
@@ -1,5 +1,6 @@
 module SimpleTokenAuthentication
   class DeviseFallbackHandler
+    include Singleton
 
     # Fallback to the Devise authentication strategies.
     def fallback!(controller, entity)

--- a/lib/simple_token_authentication/exception_fallback_handler.rb
+++ b/lib/simple_token_authentication/exception_fallback_handler.rb
@@ -1,5 +1,7 @@
 module SimpleTokenAuthentication
   class ExceptionFallbackHandler
+    include Singleton
+
     # Notifies the failure of authentication to Warden in the same DEvise does.
     # Does result in an HTTP 401 response in a Devise context.
     def fallback!(controller, entity)

--- a/lib/simple_token_authentication/sign_in_handler.rb
+++ b/lib/simple_token_authentication/sign_in_handler.rb
@@ -1,5 +1,7 @@
 module SimpleTokenAuthentication
   class SignInHandler
+    include Singleton
+
     # Devise sign in is performed through a controller
     # which includes Devise::Controllers::SignInOut
     def sign_in(controller, record, *args)

--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -79,9 +79,8 @@ module SimpleTokenAuthentication
       @@token_comparator ||= TokenComparator.new
     end
 
-    # Private: Get one (always the same) object which behaves as a sign in handler
     def sign_in_handler
-      @@sign_in_handler ||= SignInHandler.new
+      SignInHandler.instance
     end
 
     module ClassMethods

--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -74,9 +74,8 @@ module SimpleTokenAuthentication
       identifier_value
     end
 
-    # Private: Get one (always the same) object which behaves as a token comprator
     def token_comparator
-      @@token_comparator ||= TokenComparator.new
+      TokenComparator.instance
     end
 
     def sign_in_handler

--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -112,9 +112,9 @@ module SimpleTokenAuthentication
           class_variable_get(:@@fallback_authentication_handler)
         else
           if options[:fallback] == :exception
-            class_variable_set(:@@fallback_authentication_handler, ExceptionFallbackHandler.new)
+            class_variable_set(:@@fallback_authentication_handler, ExceptionFallbackHandler.instance)
           else
-            class_variable_set(:@@fallback_authentication_handler, DeviseFallbackHandler.new)
+            class_variable_set(:@@fallback_authentication_handler, DeviseFallbackHandler.instance)
           end
         end
       end

--- a/lib/simple_token_authentication/token_comparator.rb
+++ b/lib/simple_token_authentication/token_comparator.rb
@@ -2,6 +2,7 @@ require 'devise'
 
 module SimpleTokenAuthentication
   class TokenComparator
+    include Singleton
 
     # Compare two String instances
     #

--- a/lib/simple_token_authentication/token_generator.rb
+++ b/lib/simple_token_authentication/token_generator.rb
@@ -2,6 +2,8 @@ require 'devise'
 
 module SimpleTokenAuthentication
   class TokenGenerator
+    include Singleton
+
     def generate_token
       Devise.friendly_token
     end

--- a/spec/lib/simple_token_authentication/acts_as_token_authenticatable_spec.rb
+++ b/spec/lib/simple_token_authentication/acts_as_token_authenticatable_spec.rb
@@ -2,8 +2,10 @@ require 'spec_helper'
 
 
 class DummyTokenGenerator
-  def initialize(args={})
-    @tokens_to_be_generated = args[:tokens_to_be_generated]
+  include Singleton
+
+  def tokens_to_be_generated=(tokens)
+    @tokens_to_be_generated = tokens
   end
 
   def generate_token
@@ -69,8 +71,6 @@ describe 'A token authenticatable class (or one of its children)' do
 
             def initialize(args={})
               @authentication_token = args[:authentication_token]
-              @token_generator = DummyTokenGenerator.new(
-                  tokens_to_be_generated: TOKENS_IN_USE + ['Dist1nCt-Tok3N'])
             end
 
             def authentication_token=(value)
@@ -87,7 +87,9 @@ describe 'A token authenticatable class (or one of its children)' do
             end
 
             def token_generator
-              @token_generator
+              token_generator = DummyTokenGenerator.instance
+              token_generator.tokens_to_be_generated = TOKENS_IN_USE + ['Dist1nCt-Tok3N']
+              token_generator
             end
           end
         end

--- a/spec/lib/simple_token_authentication/devise_fallback_handler_spec.rb
+++ b/spec/lib/simple_token_authentication/devise_fallback_handler_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe SimpleTokenAuthentication::DeviseFallbackHandler do
 
-  it_behaves_like 'an authentication handler'
+  let(:devise_fallback_handler) { SimpleTokenAuthentication::DeviseFallbackHandler.instance }
+
+  it_behaves_like 'an authentication handler', SimpleTokenAuthentication::DeviseFallbackHandler.instance
 
   it_behaves_like 'a fallback handler'
 
@@ -17,7 +19,7 @@ describe SimpleTokenAuthentication::DeviseFallbackHandler do
 
       # delegating consists in sending the message
       expect(controller).to receive(:authenticate_user!)
-      response = subject.authenticate_entity!(controller, entity)
+      response = devise_fallback_handler.authenticate_entity!(controller, entity)
 
       # and returning the response
       expect(response).to eq 'Devise response.'
@@ -31,9 +33,9 @@ describe SimpleTokenAuthentication::DeviseFallbackHandler do
       allow(@entity).to receive_message_chain(:name_underscore).and_return('entity')
       controller = double()
 
-      expect(subject).to receive(:authenticate_entity!).with(controller, entity)
+      expect(devise_fallback_handler).to receive(:authenticate_entity!).with(controller, entity)
 
-      subject.send(:fallback!, controller, entity)
+      devise_fallback_handler.send(:fallback!, controller, entity)
     end
   end
 end

--- a/spec/lib/simple_token_authentication/exception_fallback_handler_spec.rb
+++ b/spec/lib/simple_token_authentication/exception_fallback_handler_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe SimpleTokenAuthentication::ExceptionFallbackHandler do
 
+  let(:exception_fallback_handler) { SimpleTokenAuthentication::ExceptionFallbackHandler.instance }
+
   it_behaves_like 'a fallback handler'
 
   describe '#fallback!' do
@@ -17,7 +19,7 @@ describe SimpleTokenAuthentication::ExceptionFallbackHandler do
       end
 
       it 'delegates exception throwing to Warden', private: true do
-        expect{ subject.fallback!(@controller, @entity) }.to throw_symbol(:warden, scope: :entity)
+        expect{ exception_fallback_handler.fallback!(@controller, @entity) }.to throw_symbol(:warden, scope: :entity)
       end
     end
 
@@ -32,7 +34,7 @@ describe SimpleTokenAuthentication::ExceptionFallbackHandler do
       end
 
       it 'does not throw any exception', private: true do
-        expect{ subject.fallback!(@controller, @entity) }.not_to throw_symbol(:warden, scope: :entity)
+        expect{ exception_fallback_handler.fallback!(@controller, @entity) }.not_to throw_symbol(:warden, scope: :entity)
       end
     end
   end

--- a/spec/lib/simple_token_authentication/sign_in_handler_spec.rb
+++ b/spec/lib/simple_token_authentication/sign_in_handler_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe SimpleTokenAuthentication::SignInHandler do
 
+  let(:sign_in_handler) { SimpleTokenAuthentication::SignInHandler.instance }
+
   it_behaves_like 'a sign in handler'
 
   describe '#sign_in' do
@@ -13,7 +15,7 @@ describe SimpleTokenAuthentication::SignInHandler do
 
       # delegating consists in sending the message
       expect(controller).to receive(:sign_in)
-      response = subject.sign_in(controller, :record, option: 'some_value')
+      response = sign_in_handler.sign_in(controller, :record, option: 'some_value')
 
       # and returning the response
       expect(response).to eq 'Devise response.'
@@ -24,8 +26,8 @@ describe SimpleTokenAuthentication::SignInHandler do
       allow(controller).to receive(:sign_in).with(:record)
       allow(controller).to receive(:integrate_with_devise_trackable!)
 
-      expect(subject).to receive(:integrate_with_devise_trackable!).with(controller)
-      subject.sign_in(controller, :record)
+      expect(sign_in_handler).to receive(:integrate_with_devise_trackable!).with(controller)
+      sign_in_handler.sign_in(controller, :record)
     end
   end
 
@@ -43,7 +45,7 @@ describe SimpleTokenAuthentication::SignInHandler do
         allow(controller).to receive(:env).and_return(env)
         expect(env).to receive(:[]=).with('devise.skip_trackable', true)
 
-        subject.send :integrate_with_devise_trackable!, controller
+        sign_in_handler.send :integrate_with_devise_trackable!, controller
       end
     end
 
@@ -60,7 +62,7 @@ describe SimpleTokenAuthentication::SignInHandler do
         allow(controller).to receive(:env).and_return(env)
         expect(env).to receive(:[]=).with('devise.skip_trackable', false)
 
-        subject.send :integrate_with_devise_trackable!, controller
+        sign_in_handler.send :integrate_with_devise_trackable!, controller
       end
     end
   end

--- a/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
+++ b/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
@@ -11,7 +11,7 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
     SimpleTokenAuthentication.send(:remove_const, :SomeClass)
   end
 
-  it_behaves_like 'a token authentication handler'
+  it_behaves_like 'a token authentication handler', lambda { described_class.new }
 
   let(:subject) { described_class }
 
@@ -112,44 +112,14 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
 
   describe '.fallback_handler' do
 
-    before(:each) do
-      allow(SimpleTokenAuthentication::DeviseFallbackHandler).to receive(:new)
-        .and_return('a DeviseFallbackHandler instance')
-      allow(SimpleTokenAuthentication::ExceptionFallbackHandler).to receive(:new)
-        .and_return('an ExceptionFallbackHandler instance')
-    end
-
     context 'when the Devise fallback is enabled', fallback_option: true do
 
       before(:each) do
         @options = { fallback: :devise }
       end
 
-      context 'when called for the first time' do
-
-        it 'creates a new DeviseFallbackHandler instance', private: true do
-          expect(SimpleTokenAuthentication::DeviseFallbackHandler).to receive(:new)
-          expect(subject.send(:fallback_handler, @options)).to eq 'a DeviseFallbackHandler instance'
-        end
-      end
-
-      context 'when a DeviseFallbackHandler instance was already created' do
-
-        before(:each) do
-          subject.send(:fallback_handler, @options)
-          # let's make any new DeviseFallbackHandler distinct from the first
-          allow(SimpleTokenAuthentication::DeviseFallbackHandler).to receive(:new)
-          .and_return('another DeviseFallbackHandler instance')
-        end
-
-        it 'returns that instance', private: true do
-          expect(subject.send(:fallback_handler, @options)).to eq 'a DeviseFallbackHandler instance'
-        end
-
-        it 'does not create a new DeviseFallbackHandler instance', private: true do
-          expect(SimpleTokenAuthentication::DeviseFallbackHandler).not_to receive(:new)
-          expect(subject.send(:fallback_handler, @options)).not_to eq 'another DeviseFallbackHandler instance'
-        end
+      it 'returns a DeviseFallbackHandler instance', private: true do
+        expect(subject.send(:fallback_handler, @options)).to be_kind_of SimpleTokenAuthentication::DeviseFallbackHandler
       end
     end
 
@@ -159,31 +129,8 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
         @options = { fallback: :exception }
       end
 
-      context 'when called for the first time' do
-
-        it 'creates a new ExceptionFallbackHandler instance', private: true do
-          expect(SimpleTokenAuthentication::ExceptionFallbackHandler).to receive(:new)
-          expect(subject.send(:fallback_handler, @options)).to eq 'an ExceptionFallbackHandler instance'
-        end
-      end
-
-      context 'when a ExceptionFallbackHandler instance was already created' do
-
-        before(:each) do
-          subject.send(:fallback_handler, @options)
-          # let's make any new ExceptionFallbackHandler distinct from the first
-          allow(SimpleTokenAuthentication::ExceptionFallbackHandler).to receive(:new)
-          .and_return('another ExceptionFallbackHandler instance')
-        end
-
-        it 'returns that instance', private: true do
-          expect(subject.send(:fallback_handler, @options)).to eq 'an ExceptionFallbackHandler instance'
-        end
-
-        it 'does not create a new ExceptionFallbackHandler instance', private: true do
-          expect(SimpleTokenAuthentication::ExceptionFallbackHandler).not_to receive(:new)
-          expect(subject.send(:fallback_handler, @options)).not_to eq 'another ExceptionFallbackHandler instance'
-        end
+      it 'returns a ExceptionFallbackHandler instance', private: true do
+        expect(subject.send(:fallback_handler, @options)).to be_kind_of SimpleTokenAuthentication::ExceptionFallbackHandler
       end
     end
   end

--- a/spec/lib/simple_token_authentication/token_comparator_spec.rb
+++ b/spec/lib/simple_token_authentication/token_comparator_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe SimpleTokenAuthentication::TokenComparator do
 
+  let(:token_comparator) { described_class.instance }
+
   it_behaves_like 'a token comparator'
 
   it 'delegates token comparison to Devise.secure_compare', private: true do
@@ -11,7 +13,7 @@ describe SimpleTokenAuthentication::TokenComparator do
 
     # delegating consists in sending the message
     expect(Devise).to receive(:secure_compare)
-    response = subject.compare('A_raNd0MtoKeN', 'ano4heR-Tok3n')
+    response = token_comparator.compare('A_raNd0MtoKeN', 'ano4heR-Tok3n')
 
     # and returning the response
     expect(response).to eq 'Devise.secure_compare response.'

--- a/spec/lib/simple_token_authentication/token_generator_spec.rb
+++ b/spec/lib/simple_token_authentication/token_generator_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe SimpleTokenAuthentication::TokenGenerator do
 
+  let(:token_generator) { SimpleTokenAuthentication::TokenGenerator.instance }
+
   it_behaves_like 'a token generator'
 
   it 'delegates token generation to Devise.friendly_token', private: true do
@@ -11,7 +13,7 @@ describe SimpleTokenAuthentication::TokenGenerator do
 
     # delegating consists in sending the message
     expect(Devise).to receive(:friendly_token)
-    response = subject.generate_token
+    response = token_generator.generate_token
 
     # and returning the response
     expect(response).to eq 'FRi3ndlY_TokeN'

--- a/spec/support/spec_for_authentication_handler_interface.rb
+++ b/spec/support/spec_for_authentication_handler_interface.rb
@@ -1,6 +1,4 @@
-RSpec.shared_examples 'an authentication handler' do
-
-  let(:authentication_handler) { described_class.new() }
+RSpec.shared_examples 'an authentication handler' do |authentication_handler|
 
   it 'responds to :authenticate_entity!', private: true do
     expect(authentication_handler).to respond_to :authenticate_entity!

--- a/spec/support/spec_for_fallback_handler_interface.rb
+++ b/spec/support/spec_for_fallback_handler_interface.rb
@@ -1,8 +1,12 @@
 RSpec.shared_examples 'a fallback handler' do
 
-  let(:fallback_handler) { described_class.new() }
+  let(:fallback_handler) { described_class.instance }
 
   it 'responds to :fallback!', private: true do
     expect(fallback_handler).to respond_to :fallback!
+  end
+
+  it 'is a kind of Singleton', private: true  do
+    expect(fallback_handler).to be_kind_of(Singleton)
   end
 end

--- a/spec/support/spec_for_sign_in_handler_interface.rb
+++ b/spec/support/spec_for_sign_in_handler_interface.rb
@@ -1,8 +1,12 @@
 RSpec.shared_examples 'a sign in handler' do
 
-  let(:sign_in_handler) { described_class.new() }
+  let(:sign_in_handler) { described_class.instance }
 
   it 'responds to :sign_in', private: true do
     expect(sign_in_handler).to respond_to :sign_in
+  end
+
+  it 'is a kind of Singleton', private: true  do
+    expect(sign_in_handler).to be_kind_of(Singleton)
   end
 end

--- a/spec/support/spec_for_token_comparator_interface.rb
+++ b/spec/support/spec_for_token_comparator_interface.rb
@@ -1,8 +1,12 @@
 RSpec.shared_examples 'a token comparator' do
 
-  let(:token_comparator) { described_class.new() }
+  let(:token_comparator) { described_class.instance }
 
   it 'responds to :compare', public: true do
     expect(token_comparator).to respond_to :compare
+  end
+
+  it 'is a kind of Singleton', private: true  do
+    expect(token_comparator).to be_kind_of(Singleton)
   end
 end

--- a/spec/support/spec_for_token_generator_interface.rb
+++ b/spec/support/spec_for_token_generator_interface.rb
@@ -1,8 +1,13 @@
 RSpec.shared_examples 'a token generator' do
 
-  let(:token_generator) { described_class.new() }
+  let(:token_generator) { described_class.instance }
 
   it 'responds to :generate_token', public: true do
     expect(token_generator).to respond_to :generate_token
   end
+
+  it 'is a kind of Singleton', public: true  do
+    expect(token_generator).to be_kind_of(Singleton)
+  end
 end
+


### PR DESCRIPTION
**As a** developer 
**In order to** make the `TokenAuthenticationHandler` code simpler 
**I want** to extract complexity to classes that don't change much when possible 
**And** particularly make sure that classes that behave as singletons take care of that by themselves  

Note that the `EntitiesManager` is memoized, but doesn't behave as a singleton, because the [alias option][alias] is defined per-_token authentication handler_ (controller). 

  [alias]: https://github.com/gonzalo-bulnes/simple_token_authentication/blob/v1.12.0/lib/simple_token_authentication/entities_manager.rb#L7 