### PR TITLE
Update gemspec to support Devise 4.0 release

### DIFF
--- a/lib/simple_token_authentication.rb
+++ b/lib/simple_token_authentication.rb
@@ -46,7 +46,7 @@ module SimpleTokenAuthentication
   end
 
   def self.adapter_dependency_fulfilled? adapter_short_name
-    qualified_const_defined?(SimpleTokenAuthentication.adapters_dependencies[adapter_short_name])
+    const_defined?(SimpleTokenAuthentication.adapters_dependencies[adapter_short_name])
   end
 
   available_model_adapters = load_available_adapters SimpleTokenAuthentication.model_adapters

--- a/simple_token_authentication.gemspec
+++ b/simple_token_authentication.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "actionmailer", "5.0.0.beta3"
   s.add_dependency "actionpack", "5.0.0.beta3"
-  s.add_dependency "devise", "4.0.0.rc2"
+  s.add_dependency "devise", "~> 4.0"
 
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "inch", "~> 0.4"


### PR DESCRIPTION
Devise 4.0.0 has been released https://github.com/plataformatec/devise/blob/master/CHANGELOG.md#400---2016-04-18
This is just a small change in the gemspec to support Devise 4.x