### PR TITLE
Add Devise request_keys to find_for_authentication query

### DIFF
--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -57,9 +57,17 @@ module SimpleTokenAuthentication
 
       identifier_param_value = integrate_with_devise_case_insensitive_keys(identifier_param_value, entity)
 
+      query = { entity.identifier => identifier_param_value }
+
+      if Devise.request_keys.present?
+        Devise.request_keys.each do |key|
+          query.merge!(key => request.send(key))
+        end
+      end
+
       # The finder method should be compatible with all the model adapters,
       # namely ActiveRecord and Mongoid in all their supported versions.
-      identifier_param_value && entity.model.find_for_authentication(entity.identifier => identifier_param_value)
+      identifier_param_value && entity.model.find_for_authentication(query)
     end
 
     # Private: Take benefit from Devise case-insensitive keys


### PR DESCRIPTION
When using find_for_authentication, the request keys specified in devise.rb should also be used in the query. For example, for a multi-tenant app with subdomains, the request subdomain should be queried for when it is specified.

See https://github.com/plataformatec/devise/wiki/How-to:-Scope-login-to-subdomain
