### PR TITLE
Add rails 5 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     simple_token_authentication (1.13.0)
-      actionmailer (>= 3.2.6, < 5)
-      actionpack (>= 3.2.6, < 5)
+      actionmailer (>= 3.2.6, < 5.1)
+      actionpack (>= 3.2.6, < 5.1)
       devise (>= 3.2, < 5)
 
 GEM
@@ -54,7 +54,7 @@ GEM
     builder (3.2.2)
     coderay (1.1.1)
     connection_pool (2.2.0)
-    devise (4.0.0)
+    devise (4.1.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 5.1)
@@ -76,10 +76,10 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (3.0)
+    mime-types (3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0221)
-    mini_portile2 (2.0.0)
+    mime-types-data (3.2016.0521)
+    mini_portile2 (2.1.0)
     minitest (5.8.4)
     mongoid (4.0.2)
       activemodel (~> 4.0)
@@ -90,11 +90,13 @@ GEM
       bson (~> 3.0)
       connection_pool (~> 2.0)
       optionable (~> 0.2.0)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     optionable (0.2.0)
     origin (2.2.0)
     orm_adapter (0.5.0)
+    pkg-config (1.1.7)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -116,7 +118,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.1.2)
-    responders (2.1.2)
+    responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -148,7 +150,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (>= 3.2.6, < 5)
+  activerecord (>= 3.2.6, < 5.1)
   appraisal (~> 2.0)
   inch (~> 0.4)
   mongoid (>= 3.1.0, < 5)

--- a/lib/simple_token_authentication.rb
+++ b/lib/simple_token_authentication.rb
@@ -46,7 +46,7 @@ module SimpleTokenAuthentication
   end
 
   def self.adapter_dependency_fulfilled? adapter_short_name
-    qualified_const_defined?(SimpleTokenAuthentication.adapters_dependencies[adapter_short_name])
+    const_defined?(SimpleTokenAuthentication.adapters_dependencies[adapter_short_name])
   end
 
   available_model_adapters = load_available_adapters SimpleTokenAuthentication.model_adapters

--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -144,7 +144,7 @@ module SimpleTokenAuthentication
         else
           :"authenticate_#{entity.name_underscore}_from_token"
         end
-        before_filter authenticate_method, options.slice(:only, :except, :if, :unless)
+        before_action authenticate_method, options.slice(:only, :except, :if, :unless)
       end
     end
   end

--- a/simple_token_authentication.gemspec
+++ b/simple_token_authentication.gemspec
@@ -16,13 +16,13 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,doc,lib}/**/*", "CHANGELOG.md", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*", "gemfiles/*.gemfile", "Appraisals"]
 
-  s.add_dependency "actionmailer", ">= 3.2.6", "< 5"
-  s.add_dependency "actionpack", ">= 3.2.6", "< 5"
+  s.add_dependency "actionmailer", ">= 3.2.6", "< 5.1"
+  s.add_dependency "actionpack", ">= 3.2.6", "< 5.1"
   s.add_dependency "devise", ">= 3.2", "< 5"
 
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "inch", "~> 0.4"
-  s.add_development_dependency "activerecord", ">= 3.2.6", "< 5"
+  s.add_development_dependency "activerecord", ">= 3.2.6", "< 5.1"
   s.add_development_dependency 'mongoid', '>= 3.1.0', '< 5'
   s.add_development_dependency "appraisal", "~> 2.0"
 end

--- a/spec/configuration/action_controller_callbacks_options_spec.rb
+++ b/spec/configuration/action_controller_callbacks_options_spec.rb
@@ -18,14 +18,14 @@ describe 'ActionController', action_controller_callbacks_options: true do
       it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
         some_class = @subjects.first
 
-        expect(some_class).to receive(:before_filter).with(:authenticate_user_from_token!, { only: ['some_action', :some_other_action] })
+        expect(some_class).to receive(:before_action).with(:authenticate_user_from_token!, { only: ['some_action', :some_other_action] })
         some_class.acts_as_token_authentication_handler_for User, only: ['some_action', :some_other_action]
       end
 
       it 'is applied to the corresponding callback (2)', rspec_3_error: true, private: true do
         some_child_class = @subjects.last
 
-        expect(some_child_class).to receive(:before_filter).with(:authenticate_user_from_token!, { only: ['some_action', :some_other_action] })
+        expect(some_child_class).to receive(:before_action).with(:authenticate_user_from_token!, { only: ['some_action', :some_other_action] })
         some_child_class.acts_as_token_authentication_handler_for User, only: ['some_action', :some_other_action]
       end
     end
@@ -38,14 +38,14 @@ describe 'ActionController', action_controller_callbacks_options: true do
       it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
         some_class = @subjects.first
 
-        expect(some_class).to receive(:before_filter).with(:authenticate_user_from_token!, { except: ['some_action', :some_other_action] })
+        expect(some_class).to receive(:before_action).with(:authenticate_user_from_token!, { except: ['some_action', :some_other_action] })
         some_class.acts_as_token_authentication_handler_for User, except: ['some_action', :some_other_action]
       end
 
       it 'is applied to the corresponding callback (2)', rspec_3_error: true, private: true do
         some_child_class = @subjects.last
 
-        expect(some_child_class).to receive(:before_filter).with(:authenticate_user_from_token!, { except: ['some_action', :some_other_action] })
+        expect(some_child_class).to receive(:before_action).with(:authenticate_user_from_token!, { except: ['some_action', :some_other_action] })
         some_child_class.acts_as_token_authentication_handler_for User, except: ['some_action', :some_other_action]
       end
     end
@@ -58,14 +58,14 @@ describe 'ActionController', action_controller_callbacks_options: true do
       it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
         some_class = @subjects.first
 
-        expect(some_class).to receive(:before_filter).with(:authenticate_user_from_token!, { if: lambda { |controller| 'some condition' } })
+        expect(some_class).to receive(:before_action).with(:authenticate_user_from_token!, { if: lambda { |controller| 'some condition' } })
         some_class.acts_as_token_authentication_handler_for User, if: lambda { |controller| 'some condition' }
       end
 
       it 'is applied to the corresponding callback (2)', rspec_3_error: true, private: true do
         some_child_class = @subjects.last
 
-        expect(some_child_class).to receive(:before_filter).with(:authenticate_user_from_token!, { if: lambda { |controller| 'some condition' } })
+        expect(some_child_class).to receive(:before_action).with(:authenticate_user_from_token!, { if: lambda { |controller| 'some condition' } })
         some_child_class.acts_as_token_authentication_handler_for User, if: lambda { |controller| 'some condition' }
       end
     end
@@ -78,14 +78,14 @@ describe 'ActionController', action_controller_callbacks_options: true do
       it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
         some_class = @subjects.first
 
-        expect(some_class).to receive(:before_filter).with(:authenticate_user_from_token!, { unless: lambda { |controller| 'some condition' } })
+        expect(some_class).to receive(:before_action).with(:authenticate_user_from_token!, { unless: lambda { |controller| 'some condition' } })
         some_class.acts_as_token_authentication_handler_for User, unless: lambda { |controller| 'some condition' }
       end
 
       it 'is applied to the corresponding callback (2)', rspec_3_error: true, private: true do
         some_child_class = @subjects.last
 
-        expect(some_child_class).to receive(:before_filter).with(:authenticate_user_from_token!, { unless: lambda { |controller| 'some condition' } })
+        expect(some_child_class).to receive(:before_action).with(:authenticate_user_from_token!, { unless: lambda { |controller| 'some condition' } })
         some_child_class.acts_as_token_authentication_handler_for User, unless: lambda { |controller| 'some condition' }
       end
     end

--- a/spec/configuration/fallback_to_devise_option_spec.rb
+++ b/spec/configuration/fallback_to_devise_option_spec.rb
@@ -13,7 +13,7 @@ describe 'Simple Token Authentication' do
 
         # given a controller class which acts as token authentication handler
         @controller_class = Class.new
-        allow(@controller_class).to receive(:before_filter)
+        allow(@controller_class).to receive(:before_action)
         @controller_class.send :extend, SimpleTokenAuthentication::ActsAsTokenAuthenticationHandler
       end
 
@@ -24,8 +24,8 @@ describe 'Simple Token Authentication' do
           allow(@controller).to receive(:params)
           allow(@controller).to receive(:find_record_from_identifier)
 
-          # sets :authenticate_user_from_token! (bang) in the before_filter
-          expect(@controller_class).to receive(:before_filter).with(:authenticate_user_from_token!, {})
+          # sets :authenticate_user_from_token! (bang) in the before_action
+          expect(@controller_class).to receive(:before_action).with(:authenticate_user_from_token!, {})
 
           # when falling back to Devise is enabled
           @controller_class.acts_as_token_authentication_handler_for User, fallback_to_devise: true
@@ -44,8 +44,8 @@ describe 'Simple Token Authentication' do
           allow(@controller).to receive(:params)
           allow(@controller).to receive(:find_record_from_identifier)
 
-          # sets :authenticate_user_from_token (non-bang) in the before_filter
-          expect(@controller_class).to receive(:before_filter).with(:authenticate_user_from_token, {})
+          # sets :authenticate_user_from_token (non-bang) in the before_action
+          expect(@controller_class).to receive(:before_action).with(:authenticate_user_from_token, {})
 
           # when falling back to Devise is enabled
           @controller_class.acts_as_token_authentication_handler_for User, fallback_to_devise: false
@@ -64,8 +64,8 @@ describe 'Simple Token Authentication' do
           allow(@controller).to receive(:params)
           allow(@controller).to receive(:find_record_from_identifier)
 
-          # sets :authenticate_user_from_token! (bang) in the before_filter
-          expect(@controller_class).to receive(:before_filter).with(:authenticate_user_from_token!, {})
+          # sets :authenticate_user_from_token! (bang) in the before_action
+          expect(@controller_class).to receive(:before_action).with(:authenticate_user_from_token!, {})
 
           # when falling back to Devise is enabled
           @controller_class.acts_as_token_authentication_handler_for User
@@ -92,10 +92,10 @@ describe 'Simple Token Authentication' do
             allow(@controller).to receive(:params)
             allow(@controller).to receive(:find_record_from_identifier)
 
-            # sets :authenticate_user_from_token (non-bang) in the before_filter
-            expect(@controller_class).to receive(:before_filter).with(:authenticate_user_from_token, {})
-            # sets :authenticate_admin_from_token! (bang) in the before_filter
-            expect(@controller_class).to receive(:before_filter).with(:authenticate_admin_from_token!, {})
+            # sets :authenticate_user_from_token (non-bang) in the before_action
+            expect(@controller_class).to receive(:before_action).with(:authenticate_user_from_token, {})
+            # sets :authenticate_admin_from_token! (bang) in the before_action
+            expect(@controller_class).to receive(:before_action).with(:authenticate_admin_from_token!, {})
 
             # when falling back to Devise is enabled for Admin but not User
             @controller_class.acts_as_token_authentication_handler_for User, fallback_to_devise: false

--- a/spec/configuration/header_names_option_spec.rb
+++ b/spec/configuration/header_names_option_spec.rb
@@ -37,7 +37,7 @@ describe 'Simple Token Authentication' do
 
         # given a controller class which acts as token authentication handler
         @controller_class = Class.new
-        allow(@controller_class).to receive(:before_filter)
+        allow(@controller_class).to receive(:before_action)
         @controller_class.send :extend, SimpleTokenAuthentication::ActsAsTokenAuthenticationHandler
 
         @controller = @controller_class.new
@@ -411,7 +411,7 @@ describe 'Simple Token Authentication' do
 
       # given a controller class which acts as token authentication handler
       @controller_class = Class.new
-      allow(@controller_class).to receive(:before_filter)
+      allow(@controller_class).to receive(:before_action)
       @controller_class.send :extend, SimpleTokenAuthentication::ActsAsTokenAuthenticationHandler
 
       # INITIALIZATION

--- a/spec/configuration/sign_in_token_option_spec.rb
+++ b/spec/configuration/sign_in_token_option_spec.rb
@@ -15,7 +15,7 @@ describe 'Simple Token Authentication' do
 
         # given a controller class which acts as token authentication handler
         controller_class = Class.new
-        allow(controller_class).to receive(:before_filter)
+        allow(controller_class).to receive(:before_action)
         controller_class.send :extend, SimpleTokenAuthentication::ActsAsTokenAuthenticationHandler
         # and handles authentication for a given model
         controller_class.acts_as_token_authentication_handler_for User
@@ -60,7 +60,7 @@ describe 'Simple Token Authentication' do
 
       # given a controller class which acts as token authentication handler
       controller_class = Class.new
-      allow(controller_class).to receive(:before_filter)
+      allow(controller_class).to receive(:before_action)
       controller_class.send :extend, SimpleTokenAuthentication::ActsAsTokenAuthenticationHandler
 
       allow(SimpleTokenAuthentication).to receive(:sign_in_token).and_return('initial value')

--- a/spec/configuration/skip_devise_trackable_option_spec.rb
+++ b/spec/configuration/skip_devise_trackable_option_spec.rb
@@ -15,7 +15,7 @@ describe SimpleTokenAuthentication do
 
         # given a controller class which acts as token authentication handler
         controller_class = Class.new
-        allow(controller_class).to receive(:before_filter)
+        allow(controller_class).to receive(:before_action)
         controller_class.send :extend, SimpleTokenAuthentication::ActsAsTokenAuthenticationHandler
         controller_class.acts_as_token_authentication_handler_for User
 
@@ -60,7 +60,7 @@ describe SimpleTokenAuthentication do
 
       # given a controller class which acts as token authentication handler
       controller_class = Class.new
-      allow(controller_class).to receive(:before_filter)
+      allow(controller_class).to receive(:before_action)
       controller_class.send :extend, SimpleTokenAuthentication::ActsAsTokenAuthenticationHandler
 
       allow(SimpleTokenAuthentication).to receive(:skip_devise_trackable).and_return('initial value')

--- a/spec/lib/simple_token_authentication/acts_as_token_authentication_handler_spec.rb
+++ b/spec/lib/simple_token_authentication/acts_as_token_authentication_handler_spec.rb
@@ -61,7 +61,7 @@ describe 'Any class which extends SimpleTokenAuthentication::ActsAsTokenAuthenti
       double_user_model
 
       some_class = @subjects.first
-      allow(some_class).to receive(:before_filter)
+      allow(some_class).to receive(:before_action)
 
       expect(some_class).to receive(:include).with(SimpleTokenAuthentication::TokenAuthenticationHandler)
       expect(some_class).to receive(:handle_token_authentication_for).with(User, { option: 'value' })
@@ -73,7 +73,7 @@ describe 'Any class which extends SimpleTokenAuthentication::ActsAsTokenAuthenti
       double_user_model
 
       some_child_class = @subjects.last
-      allow(some_child_class).to receive(:before_filter)
+      allow(some_child_class).to receive(:before_action)
 
       expect(some_child_class).to receive(:include).with(SimpleTokenAuthentication::TokenAuthenticationHandler)
       expect(some_child_class).to receive(:handle_token_authentication_for).with(User, { option: 'value' })

--- a/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
+++ b/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
@@ -348,10 +348,10 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
     end
   end
 
-  describe 'and which supports the :before_filter hook' do
+  describe 'and which supports the :before_action hook' do
 
     before(:each) do
-      allow(subject).to receive(:before_filter)
+      allow(subject).to receive(:before_action)
     end
 
     # User
@@ -363,7 +363,7 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
       end
 
       it 'ensures its instances require user to authenticate from token or any Devise strategy before any action', public: true do
-        expect(subject).to receive(:before_filter).with(:authenticate_user_from_token!, {})
+        expect(subject).to receive(:before_action).with(:authenticate_user_from_token!, {})
         subject.handle_token_authentication_for User
       end
 
@@ -374,7 +374,7 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
         end
 
         it 'ensures its instances require user to authenticate from token before any action', public: true do
-          expect(subject).to receive(:before_filter).with(:authenticate_user_from_token, {})
+          expect(subject).to receive(:before_action).with(:authenticate_user_from_token, {})
           subject.handle_token_authentication_for User, options
         end
       end
@@ -416,7 +416,7 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
       end
 
       it 'ensures its instances require super_admin to authenticate from token or any Devise strategy before any action', public: true do
-        expect(subject).to receive(:before_filter).with(:authenticate_super_admin_from_token!, {})
+        expect(subject).to receive(:before_action).with(:authenticate_super_admin_from_token!, {})
         subject.handle_token_authentication_for SuperAdmin
       end
 
@@ -427,7 +427,7 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
         end
 
         it 'ensures its instances require super_admin to authenticate from token before any action', public: true do
-          expect(subject).to receive(:before_filter).with(:authenticate_super_admin_from_token, {})
+          expect(subject).to receive(:before_action).with(:authenticate_super_admin_from_token, {})
           subject.handle_token_authentication_for SuperAdmin, options
         end
       end
@@ -466,7 +466,7 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
         end
 
         it 'ensures its instances require admin to authenticate from token or any Devise strategy before any action', public: true do
-          expect(subject).to receive(:before_filter).with(:authenticate_admin_from_token!, {})
+          expect(subject).to receive(:before_action).with(:authenticate_admin_from_token!, {})
           subject.handle_token_authentication_for SuperAdmin, options
         end
 
@@ -477,7 +477,7 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
           end
 
           it 'ensures its instances require admin to authenticate from token before any action', public: true do
-            expect(subject).to receive(:before_filter).with(:authenticate_admin_from_token, {})
+            expect(subject).to receive(:before_action).with(:authenticate_admin_from_token, {})
             subject.handle_token_authentication_for SuperAdmin, options
           end
         end


### PR DESCRIPTION
In order to provide the initial rails 5.0.0 support I suggest unlock versions of rails dependent gems up to 5.1 and replace deprecated method call. Of course it might not resolve all version compatibility problems but it is something to start with.

BTW: I sent you an email. 