### PR TITLE
Fix prevent Rails API adapter from breaking jbuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+## Fixed
+
+- Work around [jbuilder][jbuilder] issues caused by the Rails API adapter - @IvRRimum with help from @Pepan
+
+  [jbuilder]: https://github.com/rails/jbuilder
+
 ## [1.15.0] - 2017-01-14
 
 ### Added
@@ -260,6 +268,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This [gist][gist] did refactor the Jose Valim's code into an `ActiveSupport::Concern`.
 
 [gist]: https://gist.github.com/gonzalo-bulnes/7659739
+[Unreleased]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.15.0...master
 [1.15.0]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/gonzalo-bulnes/simple_token_authentication/compare/v1.12.0...v1.13.0

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ License
 -------
 
     Simple Token Authentication
-    Copyright (C) 2013, 2014, 2015, 2016 Gonzalo Bulnes Guilpain
+    Copyright (C) 2013, 2014, 2015, 2016, 2017 Gonzalo Bulnes Guilpain
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/lib/simple_token_authentication.rb
+++ b/lib/simple_token_authentication.rb
@@ -33,7 +33,8 @@ module SimpleTokenAuthentication
   # Returns an Array of available adapters
   def self.load_available_adapters adapters_short_names
     available_adapters = adapters_short_names.collect do |short_name|
-      next if short_name == "rails_api"
+      next if short_name == 'rails' && (ActiveSupport.respond_to?(:version) && ActiveSupport.version >= Gem::Version.new('4.1.0'))
+      next if short_name == 'rails_api' && (ActiveSupport.respond_to?(:version) && ActiveSupport.version >= Gem::Version.new('5.0.0'))
       adapter_name = "simple_token_authentication/adapters/#{short_name}_adapter"
       if adapter_dependency_fulfilled?(short_name) && require(adapter_name)
         adapter_name.camelize.constantize

--- a/lib/simple_token_authentication.rb
+++ b/lib/simple_token_authentication.rb
@@ -33,6 +33,7 @@ module SimpleTokenAuthentication
   # Returns an Array of available adapters
   def self.load_available_adapters adapters_short_names
     available_adapters = adapters_short_names.collect do |short_name|
+      next if short_name == "rails_api"
       adapter_name = "simple_token_authentication/adapters/#{short_name}_adapter"
       if adapter_dependency_fulfilled?(short_name) && require(adapter_name)
         adapter_name.camelize.constantize

--- a/spec/configuration/action_controller_callbacks_options_spec.rb
+++ b/spec/configuration/action_controller_callbacks_options_spec.rb
@@ -13,7 +13,7 @@ describe 'ActionController', action_controller_callbacks_options: true do
 
   describe ':only option', before_filter: true do
 
-    context 'when provided to `acts_as_token_authentication_hanlder_for`' do
+    context 'when provided to `acts_as_token_authentication_handler_for`' do
 
       it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
         some_class = @subjects.first
@@ -33,7 +33,7 @@ describe 'ActionController', action_controller_callbacks_options: true do
 
   describe ':except option', before_filter: true do
 
-    context 'when provided to `acts_as_token_authentication_hanlder_for`' do
+    context 'when provided to `acts_as_token_authentication_handler_for`' do
 
       it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
         some_class = @subjects.first
@@ -53,7 +53,7 @@ describe 'ActionController', action_controller_callbacks_options: true do
 
   describe ':if option', before_filter: true do
 
-    context 'when provided to `acts_as_token_authentication_hanlder_for`' do
+    context 'when provided to `acts_as_token_authentication_handler_for`' do
 
       it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
         some_class = @subjects.first
@@ -73,7 +73,7 @@ describe 'ActionController', action_controller_callbacks_options: true do
 
   describe ':unless option', before_filter: true do
 
-    context 'when provided to `acts_as_token_authentication_hanlder_for`' do
+    context 'when provided to `acts_as_token_authentication_handler_for`' do
 
       it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
         some_class = @subjects.first
@@ -95,7 +95,7 @@ describe 'ActionController', action_controller_callbacks_options: true do
 
     describe ':only option' do
 
-      context 'when provided to `acts_as_token_authentication_hanlder_for`' do
+      context 'when provided to `acts_as_token_authentication_handler_for`' do
 
         it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
           some_class = @subjects.first
@@ -115,7 +115,7 @@ describe 'ActionController', action_controller_callbacks_options: true do
 
     describe ':except option' do
 
-      context 'when provided to `acts_as_token_authentication_hanlder_for`' do
+      context 'when provided to `acts_as_token_authentication_handler_for`' do
 
         it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
           some_class = @subjects.first
@@ -135,7 +135,7 @@ describe 'ActionController', action_controller_callbacks_options: true do
 
     describe ':if option' do
 
-      context 'when provided to `acts_as_token_authentication_hanlder_for`' do
+      context 'when provided to `acts_as_token_authentication_handler_for`' do
 
         it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
           some_class = @subjects.first
@@ -155,7 +155,7 @@ describe 'ActionController', action_controller_callbacks_options: true do
 
     describe ':unless option' do
 
-      context 'when provided to `acts_as_token_authentication_hanlder_for`' do
+      context 'when provided to `acts_as_token_authentication_handler_for`' do
 
         it 'is applied to the corresponding callback (1)', rspec_3_error: true, private: true do
           some_class = @subjects.first


### PR DESCRIPTION
**When I** use [jbuilder][jbuilder] to render JSON responses 
**And** loading the Rails Metal adapter is enough to allow my controllers to act as token authentication handlers 
**I want** to skip loading the Rails API adapter 
**So that** it doesn't interfere with _jbuilder_ 

**Note**: While we don't want to load unnecessary adapters, the _jbuilder_ issue si only worked around and its root cause still has to be identified.

  [jbuilder]: https://github.com/rails/jbuilder

Fixes #278 
Fixes #286 
Closes #288 
Closes #282