### PR TITLE
Model should set authentication token value before validation

### DIFF
--- a/lib/simple_token_authentication/acts_as_token_authenticatable.rb
+++ b/lib/simple_token_authentication/acts_as_token_authenticatable.rb
@@ -41,7 +41,7 @@ module SimpleTokenAuthentication
 
     module ClassMethods
       def acts_as_token_authenticatable(options = {})
-        before_save :ensure_authentication_token
+        before_validation :ensure_authentication_token
       end
     end
   end

--- a/spec/lib/simple_token_authentication/acts_as_token_authenticatable_spec.rb
+++ b/spec/lib/simple_token_authentication/acts_as_token_authenticatable_spec.rb
@@ -33,20 +33,20 @@ describe 'A token authenticatable class (or one of its children)' do
     end
   end
 
-  describe 'which supports the :before_save hook' do
+  describe 'which supports the :before_validation hook' do
 
     context 'when it acts as token authenticatable' do
       it 'ensures its instances have an authentication token before being saved (1)', rspec_3_error: true, public: true do
         some_class = @subjects.first
 
-        expect(some_class).to receive(:before_save).with(:ensure_authentication_token)
+        expect(some_class).to receive(:before_validation).with(:ensure_authentication_token)
         some_class.acts_as_token_authenticatable
       end
 
       it 'ensures its instances have an authentication token before being saved (2)', rspec_3_error: true, public: true do
         some_child_class = @subjects.last
 
-        expect(some_child_class).to receive(:before_save).with(:ensure_authentication_token)
+        expect(some_child_class).to receive(:before_validation).with(:ensure_authentication_token)
         some_child_class.acts_as_token_authenticatable
       end
     end


### PR DESCRIPTION
I have a simple model:

```
class User < ApplicationRecord
  acts_as_token_authenticatable

  validates :service, presence: true, uniqueness: {case_sensitive: false}
  validates :authentication_token, presence: true, uniqueness: true
end
```

Testing this fails because `acts_as_token_authenticatable` sets the `before_save` validation which is not run until _after_ validation:

```
2.3.1 :008 > User.create(service: "alpha")
   (2.1ms)  BEGIN
  User Exists (0.6ms)  SELECT  1 AS one FROM "users" WHERE LOWER("users"."service") = LOWER('alpha') LIMIT 1
  User Exists (0.6ms)  SELECT  1 AS one FROM "users" WHERE "users"."authentication_token" = '' LIMIT 1
   (0.2ms)  ROLLBACK
+----+---------+----------------------+
| id | service | authentication_token |
+----+---------+----------------------+
|    | alpha   |                      |
+----+---------+----------------------+
```

If the default behavior for `simple_token_authentication` is to set the `authentication_token` for any model that doesn't have one, then I think it makes sense to validate that as well.

This pull request resolves that by using `before_validation` callback which is supported by both ActiveRecord and Mongoid.
