### PR TITLE
Add support for Cassandra and Cequel. Resolves #315

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (>= 3.2.6, < 6)
   appraisal (~> 2.0)
-  cequel (~> 3.0)
+  cequel (>= 1.0, < 4)
   inch (~> 0.4)
   mongoid (>= 3.1.0, < 7)
   rspec (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simple_token_authentication (1.15.1)
+    simple_token_authentication (1.15.2)
       actionmailer (>= 3.2.6, < 6)
       actionpack (>= 3.2.6, < 6)
       devise (>= 3.2, < 6)
@@ -50,6 +50,11 @@ GEM
     bcrypt (3.1.11)
     bson (4.2.1)
     builder (3.2.3)
+    cassandra-driver (3.2.0)
+      ione (~> 1.2)
+    cequel (3.0.0)
+      activemodel (>= 4.0)
+      cassandra-driver (~> 3.0)
     coderay (1.1.1)
     concurrent-ruby (1.0.4)
     devise (4.2.0)
@@ -68,6 +73,7 @@ GEM
       sparkr (>= 0.2.0)
       term-ansicolor
       yard (~> 0.8.7.5)
+    ione (1.2.4)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -139,6 +145,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (>= 3.2.6, < 6)
   appraisal (~> 2.0)
+  cequel (~> 3.0)
   inch (~> 0.4)
   mongoid (>= 3.1.0, < 7)
   rspec (~> 3.0)

--- a/lib/simple_token_authentication/acts_as_token_authenticatable.rb
+++ b/lib/simple_token_authentication/acts_as_token_authenticatable.rb
@@ -32,7 +32,7 @@ module SimpleTokenAuthentication
     end
 
     def token_suitable?(token)
-      self.class.where(authentication_token: token).count == 0
+      self.class.find_by_authentication_token(token).nil?
     end
 
     def token_generator

--- a/lib/simple_token_authentication/adapters/cequel_adapter.rb
+++ b/lib/simple_token_authentication/adapters/cequel_adapter.rb
@@ -1,0 +1,14 @@
+require 'cequel'
+require 'simple_token_authentication/adapter'
+
+module SimpleTokenAuthentication
+  module Adapters
+    class CequelAdapter
+      extend SimpleTokenAuthentication::Adapter
+
+      def self.base_class
+        ::Cequel::Record
+      end
+    end
+  end
+end

--- a/lib/simple_token_authentication/configuration.rb
+++ b/lib/simple_token_authentication/configuration.rb
@@ -16,8 +16,9 @@ module SimpleTokenAuthentication
     @@identifiers = {}
     @@sign_in_token = false
     @@controller_adapters = ['rails', 'rails_api', 'rails_metal']
-    @@model_adapters = ['active_record', 'mongoid']
+    @@model_adapters = ['active_record', 'cequel', 'mongoid']
     @@adapters_dependencies = { 'active_record' => 'ActiveRecord::Base',
+                                'cequel'        => 'Cequel::Record',
                                 'mongoid'       => 'Mongoid::Document',
                                 'rails'         => 'ActionController::Base',
                                 'rails_api'     => 'ActionController::API',

--- a/lib/simple_token_authentication/version.rb
+++ b/lib/simple_token_authentication/version.rb
@@ -1,3 +1,3 @@
 module SimpleTokenAuthentication
-  VERSION = "1.15.1".freeze
+  VERSION = "1.15.2".freeze
 end

--- a/simple_token_authentication.gemspec
+++ b/simple_token_authentication.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "inch", "~> 0.4"
   s.add_development_dependency "activerecord", ">= 3.2.6", "< 6"
-  s.add_development_dependency "cequel", "~> 3.0"
+  s.add_development_dependency "cequel", ">= 1.0", "< 4"
   s.add_development_dependency 'mongoid', '>= 3.1.0', '< 7'
   s.add_development_dependency "appraisal", "~> 2.0"
 end

--- a/simple_token_authentication.gemspec
+++ b/simple_token_authentication.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "inch", "~> 0.4"
   s.add_development_dependency "activerecord", ">= 3.2.6", "< 6"
+  s.add_development_dependency "cequel", "~> 3.0"
   s.add_development_dependency 'mongoid', '>= 3.1.0', '< 7'
   s.add_development_dependency "appraisal", "~> 2.0"
 end

--- a/spec/lib/simple_token_authentication/adapters/cequel_adapter_spec.rb
+++ b/spec/lib/simple_token_authentication/adapters/cequel_adapter_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'simple_token_authentication/adapters/cequel_adapter'
+
+describe 'SimpleTokenAuthentication::Adapters::CequelAdapter' do
+
+  before(:each) do
+    stub_const('Cequel', Module.new)
+    stub_const('Cequel::Record', double())
+
+    @subject = SimpleTokenAuthentication::Adapters::CequelAdapter
+  end
+
+  it_behaves_like 'an adapter'
+
+  describe '.base_class' do
+
+    it 'is Cequel::Record', private: true do
+      expect(@subject.base_class).to eq Cequel::Record
+    end
+  end
+end

--- a/spec/lib/simple_token_authentication/configuration_spec.rb
+++ b/spec/lib/simple_token_authentication/configuration_spec.rb
@@ -29,8 +29,8 @@ describe SimpleTokenAuthentication::Configuration do
 
       it_behaves_like 'a configuration option', 'model_adapters'
 
-      it "defauts to ['active_record', 'mongoid']", private: true do
-        expect(@subject.model_adapters).to eq ['active_record', 'mongoid']
+      it "defauts to ['active_record', 'cequel', 'mongoid']", private: true do
+        expect(@subject.model_adapters).to eq ['active_record', 'cequel', 'mongoid']
       end
     end
 
@@ -40,6 +40,7 @@ describe SimpleTokenAuthentication::Configuration do
 
       it 'lists the supported adapters dependencies by default', private: true do
         expect(@subject.adapters_dependencies['active_record']).to eq 'ActiveRecord::Base'
+        expect(@subject.adapters_dependencies['cequel']).to eq 'Cequel::Record'
         expect(@subject.adapters_dependencies['mongoid']).to eq 'Mongoid::Document'
         expect(@subject.adapters_dependencies['rails']).to eq 'ActionController::Base'
         expect(@subject.adapters_dependencies['rails_api']).to eq 'ActionController::API'


### PR DESCRIPTION
Adds support for simple_token_authentication when dealing with Cequel::Record(s).

count() could cause a full scan of table on Cassandra and thus Cequel throws DangerousQueryError. find_by_authentication_token() uses the already present index.