### PR TITLE
Use respond_to instead of having a blank implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ To use no fallback when token authentication fails, set `fallback: :none`.
 
 ### Hooks
 
-One hook is currently available to trigger custom behaviour after an user has been successfully authenticated through token authentication. To use it, override the `after_successful_token_authentication` method in the corresponding token authentication handler:
+One hook is currently available to trigger custom behaviour after an user has been successfully authenticated through token authentication. To use it, implement or mixin a module with an `after_successful_token_authentication` method that will be ran after authentication from a token authentication handler:
 
 ```ruby
 # app/controller/application_controller.rb

--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -27,20 +27,21 @@ module SimpleTokenAuthentication
       private :integrate_with_devise_case_insensitive_keys
     end
 
-    # This method is a hook and is meant to be overridden.
+    # This method is a hook and can be implemented if you need it.
     #
     # It is not expected to return anything special,
     # only its side effects will be used.
-    def after_successful_token_authentication
-      # intentionally left blank
-    end
+    #
+    #   def after_successful_token_authentication
+    #     # code that will be ran after sign through JSON token
+    #   end
 
     def authenticate_entity_from_token!(entity)
       record = find_record_from_identifier(entity)
 
       if token_correct?(record, entity, token_comparator)
         perform_sign_in!(record, sign_in_handler)
-        after_successful_token_authentication
+        after_successful_token_authentication if respond_to?(:after_successful_token_authentication)
       end
     end
 

--- a/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
+++ b/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
@@ -693,29 +693,47 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
   end
 
   describe '#authenticate_entity_from_token!' do
-
     let(:token_authentication_handler) { described_class.new }
 
     before(:each) do
-        allow(token_authentication_handler).to receive(:find_record_from_identifier)
-        allow(token_authentication_handler).to receive(:perform_sign_in!)
+      allow(token_authentication_handler).to receive(:find_record_from_identifier)
+      allow(token_authentication_handler).to receive(:perform_sign_in!)
+      allow(token_authentication_handler).to receive(:token_correct?).and_return(false)
+    end
+
+    context 'when authentication is not succesful and the handler implements the :after_successful_token_authentication hook', private: true do
+      before(:each) do
         allow(token_authentication_handler).to receive(:token_correct?).and_return(false)
+        allow(token_authentication_handler).to receive(:after_successful_token_authentication)
+      end
+
+      it 'does not trigger the :after_successful_token_authentication hook' do
+        token_authentication_handler.send(:authenticate_entity_from_token!, double)
+        expect(token_authentication_handler).not_to have_received(:after_successful_token_authentication)
+      end
     end
 
-    it 'does not trigger the :after_successful_token_authentication hook', hooks: true, private: true do
-      expect(token_authentication_handler).not_to receive(:after_successful_token_authentication)
-      token_authentication_handler.send(:authenticate_entity_from_token!, double)
-    end
-
-    context 'after successful authentication' do
-
+    context 'when authentication is succesful' do
       before(:each) do
         allow(token_authentication_handler).to receive(:token_correct?).and_return(true)
       end
 
-      it 'calls the :after_successful_token_authentication hook', hooks: true, protected: true do
-        expect(token_authentication_handler).to receive(:after_successful_token_authentication).once
-        token_authentication_handler.send(:authenticate_entity_from_token!, double)
+      context 'when the handler does not implement :after_successful_token_authentication', protected: true do
+        it 'does not trigger the :after_successful_token_authentication hook' do
+          expect(token_authentication_handler).not_to respond_to(:after_successful_token_authentication)
+          expect { token_authentication_handler.send(:authenticate_entity_from_token!, double) }.not_to raise_error
+        end
+      end
+
+      context 'when the handler implements :after_successful_token_authentication', protected: true do
+        before(:each) do
+          allow(token_authentication_handler).to receive(:after_successful_token_authentication)
+        end
+
+        it 'calls the :after_successful_token_authentication hook' do
+          token_authentication_handler.send(:authenticate_entity_from_token!, double)
+          expect(token_authentication_handler).to have_received(:after_successful_token_authentication).once
+        end
       end
     end
   end

--- a/spec/support/specs_for_token_authentication_handler_interface.rb
+++ b/spec/support/specs_for_token_authentication_handler_interface.rb
@@ -7,9 +7,8 @@ RSpec.shared_examples 'a token authentication handler' do
   end
 
   describe 'instance' do
-
-    it 'responds to :after_successful_token_authentication', hooks: true, private: true do
-      expect(token_authentication_handler.new).to respond_to :after_successful_token_authentication
+    it 'does not implement :after_successful_token_authentication by default', private: true do
+      expect(token_authentication_handler.new).not_to respond_to :after_successful_token_authentication
     end
   end
 end


### PR DESCRIPTION
Do not use a blank implementation for hooks that would override exiistng ones if they were declared before the acts_as_token_authentication_handler_for method (eg. via a mixin)

Fix for https://github.com/gonzalo-bulnes/simple_token_authentication/issues/217#issuecomment-378886251