### PR TITLE
Add Rails 6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test/dummy/.sass-cache
 
 # Rubygems
 *.gem
+*.lock
 
 # RVM
 .ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 gemfile:
+  - gemfiles/rails_6_devise_4.gemfile
   - gemfiles/rails_5_devise_4.gemfile
   - gemfiles/rails_4_devise_3.gemfile
   - gemfiles/ruby_1.9.3_rails_3.2.gemfile
@@ -11,6 +12,8 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   exclude:
+    - rvm: 1.9.3
+      gemfile: gemfiles/rails_6_devise_4.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails_5_devise_4.gemfile
     - rvm: 1.9.3

--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,11 @@
-appraise 'rails_5_devise_4' do
+appraise 'rails_6_devise_4' do
   # use gemspec constraints
+end
+
+appraise 'rails_5_devise_4' do
+  gem 'actionmailer', '~> 5.0'
+  gem 'actionpack', '~> 5.0'
+  gem 'activerecord', '~> 5.0'
 end
 
 appraise 'rails_4_devise_3' do

--- a/Appraisals
+++ b/Appraisals
@@ -22,4 +22,5 @@ appraise 'ruby_1.9.3_rails_3.2' do
   gem 'mime-types', '< 3'
   gem 'term-ansicolor', '~> 1.3.0'
   gem 'tins', '< 1.7.0'
+  gem 'yard', '<= 0.9.5'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] - 2017-12-21
+## [Unreleased] - 2019-08-20
 
-## Fixed
+### Added
+
+- Add Rails 6 support - @MatthiasRMS
+
+### Fixed
 
 - Removed the `Gemfile.lock` - mostly to acknowledge that it was used only in development and is not really needed.
 
 ## [1.15.1] - 2017-01-26
 
-## Fixed
+### Fixed
 
 - Work around [jbuilder][jbuilder] issues caused by the Rails API adapter - @IvRRimum with help from @Pepan
 
@@ -307,4 +311,3 @@ This [gist][gist] did refactor the Jose Valim's code into an `ActiveSupport::Con
 ## Inspiration
 
 Thanks to @nTraum for pointing me at http://keepachangelog.com and to @olivierlacan for writing it in the first place!
-

--- a/gemfiles/rails_4_devise_3.gemfile
+++ b/gemfiles/rails_4_devise_3.gemfile
@@ -7,4 +7,4 @@ gem "actionpack", "~> 4.0"
 gem "activerecord", "~> 4.0"
 gem "devise", "~> 3.2"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_6_devise_4.gemfile
+++ b/gemfiles/rails_6_devise_4.gemfile
@@ -2,8 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "actionmailer", "~> 5.0"
-gem "actionpack", "~> 5.0"
-gem "activerecord", "~> 5.0"
-
 gemspec path: "../"

--- a/gemfiles/ruby_1.9.3_rails_3.2.gemfile
+++ b/gemfiles/ruby_1.9.3_rails_3.2.gemfile
@@ -8,5 +8,6 @@ gem "activerecord", ">= 3.2.15", "< 4"
 gem "mime-types", "< 3"
 gem "term-ansicolor", "~> 1.3.0"
 gem "tins", "< 1.7.0"
+gem "yard", "<= 0.9.5"
 
 gemspec path: "../"

--- a/gemfiles/ruby_1.9.3_rails_3.2.gemfile
+++ b/gemfiles/ruby_1.9.3_rails_3.2.gemfile
@@ -9,4 +9,4 @@ gem "mime-types", "< 3"
 gem "term-ansicolor", "~> 1.3.0"
 gem "tins", "< 1.7.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/simple_token_authentication.gemspec
+++ b/simple_token_authentication.gemspec
@@ -16,13 +16,13 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,doc,lib}/**/*", "CHANGELOG.md", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*", "gemfiles/*.gemfile", "gemfiles/*.gemfile.lock", "Appraisals"]
 
-  s.add_dependency "actionmailer", ">= 3.2.6", "< 6"
-  s.add_dependency "actionpack", ">= 3.2.6", "< 6"
+  s.add_dependency "actionmailer", ">= 3.2.6", "< 7"
+  s.add_dependency "actionpack", ">= 3.2.6", "< 7"
   s.add_dependency "devise", ">= 3.2", "< 6"
 
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "inch", "~> 0.4"
-  s.add_development_dependency "activerecord", ">= 3.2.6", "< 6"
+  s.add_development_dependency "activerecord", ">= 3.2.6", "< 7"
   s.add_development_dependency 'mongoid', '>= 3.1.0', '< 7'
   s.add_development_dependency "appraisal", "~> 2.0"
 end


### PR DESCRIPTION
The only relevant different between this PR and https://github.com/gonzalo-bulnes/simple_token_authentication/pull/347 is the constraint on Yard _when using Ruby 1.9.3_ (allows to preserve the compatibility with Ruby 1.9.3).

Please refer to https://github.com/gonzalo-bulnes/simple_token_authentication/pull/347 for details.

Closes https://github.com/gonzalo-bulnes/simple_token_authentication/pull/347