### PR TITLE
Prevent loading of Mongoid adapter when reasonable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ gemfile:
   - gemfiles/ruby_1.9.3_rails_3.2.gemfile
 rvm:
   - "1.9.3"
-  - "2.2.2"
+  - "2.6.3"
   - ruby-head
 matrix:
   allow_failures:
@@ -18,7 +18,7 @@ matrix:
       gemfile: gemfiles/rails_5_devise_4.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/rails_4_devise_3.gemfile
-    - rvm: 2.2.2
+    - rvm: 2.6.3
       gemfile: gemfiles/ruby_1.9.3_rails_3.2.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails_4_devise_3.gemfile

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Simple Token Authentication
 [![Gem Version](https://badge.fury.io/rb/simple_token_authentication.svg)](http://badge.fury.io/rb/simple_token_authentication)
 [![Build Status](https://travis-ci.org/gonzalo-bulnes/simple_token_authentication.svg?branch=master)](https://travis-ci.org/gonzalo-bulnes/simple_token_authentication)
 [![Code Climate](https://codeclimate.com/github/gonzalo-bulnes/simple_token_authentication.svg)](https://codeclimate.com/github/gonzalo-bulnes/simple_token_authentication)
-[![Dependency Status](https://gemnasium.com/gonzalo-bulnes/simple_token_authentication.svg)](https://gemnasium.com/gonzalo-bulnes/simple_token_authentication)
-[![security](https://hakiri.io/github/gonzalo-bulnes/simple_token_authentication/master.svg)](https://hakiri.io/github/gonzalo-bulnes/simple_token_authentication/master)
+[![Security](https://hakiri.io/github/gonzalo-bulnes/simple_token_authentication/master.svg)](https://hakiri.io/github/gonzalo-bulnes/simple_token_authentication/master)
 [![Inline docs](http://inch-ci.org/github/gonzalo-bulnes/simple_token_authentication.svg?branch=master)](http://inch-ci.org/github/gonzalo-bulnes/simple_token_authentication)
 
 Token authentication support has been removed from [Devise][devise] for security reasons. In [this gist][original-gist], Devise's [José Valim][josevalim] explains how token authentication should be performed in order to remain safe.

--- a/lib/simple_token_authentication/adapters/mongoid_adapter.rb
+++ b/lib/simple_token_authentication/adapters/mongoid_adapter.rb
@@ -1,13 +1,20 @@
-require 'mongoid'
-require 'simple_token_authentication/adapter'
+if Module.const_defined?('ActiveModel') &&
+  ActiveModel.const_defined?('Serializers') &&
+  ActiveModel::Serializers.const_defined?('Xml')
+  # As far as I know Mongoid doesn't support Rails 6
+  # Please let me know if this isn't true when you read it!
 
-module SimpleTokenAuthentication
-  module Adapters
-    class MongoidAdapter
-      extend SimpleTokenAuthentication::Adapter
+  require 'mongoid'
+  require 'simple_token_authentication/adapter'
 
-      def self.base_class
-        ::Mongoid::Document
+  module SimpleTokenAuthentication
+    module Adapters
+      class MongoidAdapter
+        extend SimpleTokenAuthentication::Adapter
+
+        def self.base_class
+          ::Mongoid::Document
+        end
       end
     end
   end

--- a/spec/lib/simple_token_authentication/adapters/mongoid_adapter_spec.rb
+++ b/spec/lib/simple_token_authentication/adapters/mongoid_adapter_spec.rb
@@ -1,21 +1,28 @@
-require 'spec_helper'
-require 'simple_token_authentication/adapters/mongoid_adapter'
+if Module.const_defined?('ActiveModel') &&
+  ActiveModel.const_defined?('Serializers') &&
+  ActiveModel::Serializers.const_defined?('Xml')
+  # As far as I know Mongoid doesn't support Rails 6
+  # Please let me know if this isn't true when you read it!
 
-describe 'SimpleTokenAuthentication::Adapters::MongoidAdapter' do
+  require 'spec_helper'
+  require 'simple_token_authentication/adapters/mongoid_adapter'
 
-  before(:each) do
-    stub_const('Mongoid', Module.new)
-    stub_const('Mongoid::Document', double())
+  describe 'SimpleTokenAuthentication::Adapters::MongoidAdapter' do
 
-    @subject = SimpleTokenAuthentication::Adapters::MongoidAdapter
-  end
+    before(:each) do
+      stub_const('Mongoid', Module.new)
+      stub_const('Mongoid::Document', double())
 
-  it_behaves_like 'an adapter'
+      @subject = SimpleTokenAuthentication::Adapters::MongoidAdapter
+    end
 
-  describe '.base_class' do
+    it_behaves_like 'an adapter'
 
-    it 'is Mongoid::Document', private: true do
-      expect(@subject.base_class).to eq Mongoid::Document
+    describe '.base_class' do
+
+      it 'is Mongoid::Document', private: true do
+        expect(@subject.base_class).to eq Mongoid::Document
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ Bundler.setup
 
 require 'action_controller'
 require 'active_record'
-require 'mongoid'
 require 'active_support'
 
 require 'simple_token_authentication'


### PR DESCRIPTION
**When** I use a version of Ruby and a version of Rails that are not compatible with the use of Monogoid 
**I want** to be able to run the test suite as usual 
Even if it means not loading the Mongoid adapter code (because I am not using it anyway)
**So that** I can contribute to the development or maintenance of a gem that I use  


----

Running the test suite easily (a.k.a running `rake` without parameters) is not optional.

With recent versions of Ruby (2.5 for sure) and of Rails (6 for sure), Mongoid doesn't find `ActiveModel::Serializers::Xml`. Because the Mongoid adapter does `require 'mongoid'` when the test suite is run, this situation [breaks the test suite](https://travis-ci.org/gonzalo-bulnes/simple_token_authentication/jobs/574214405#L382).

I believe anyone using Mongoid would ensure that the version they use is compatible with their version of Rails and Ruby. Because of that, loading the adapter only when that is true seems reasonable.

**Why only the `ruby-head` build is failing with Rails 6?**

Because the other Rails 6 build runs on Ruby 2.2.2, I believe that the versions of Mongoid that is installed is different...?

**About the syntax**

The condition [must be compatible with Ruby 1.9.3](https://travis-ci.org/gonzalo-bulnes/simple_token_authentication/jobs/574239985#L357).

**References**

- [ActiveModel::Serializers::Xml extraction from in Rails 5](https://github.com/rails/rails/blob/891ac4e2f1a9b63d3cbf2b1cadf976669ed89a1b/guides/source/upgrading_ruby_on_rails.md#xml-serialization)
- [Recent version of the Mongoid gem require recent Rubies](https://github.com/mongodb/mongoid/releases/tag/v5.4.0)