### PR TITLE
Enable mongoid adapter to be used with rails 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Add Rails 6 support for Mongoid Adapter - @unused
+
 ## [1.16.0] - 2019-08-20
 
 ### Added

--- a/lib/simple_token_authentication/adapters/mongoid_adapter.rb
+++ b/lib/simple_token_authentication/adapters/mongoid_adapter.rb
@@ -1,20 +1,13 @@
-if Module.const_defined?('ActiveModel') &&
-  ActiveModel.const_defined?('Serializers') &&
-  ActiveModel::Serializers.const_defined?('Xml')
-  # As far as I know Mongoid doesn't support Rails 6
-  # Please let me know if this isn't true when you read it!
+require 'mongoid'
+require 'simple_token_authentication/adapter'
 
-  require 'mongoid'
-  require 'simple_token_authentication/adapter'
+module SimpleTokenAuthentication
+  module Adapters
+    class MongoidAdapter
+      extend SimpleTokenAuthentication::Adapter
 
-  module SimpleTokenAuthentication
-    module Adapters
-      class MongoidAdapter
-        extend SimpleTokenAuthentication::Adapter
-
-        def self.base_class
-          ::Mongoid::Document
-        end
+      def self.base_class
+        ::Mongoid::Document
       end
     end
   end

--- a/lib/simple_token_authentication/errors.rb
+++ b/lib/simple_token_authentication/errors.rb
@@ -12,7 +12,7 @@ module SimpleTokenAuthentication
 
             # Gemfile
 
-            gem 'mongoid', '~> 4.0' # for example
+            gem 'mongoid', '~> 7.0.5' # for example
             gem 'simple_token_authentication', '~> 1.0'
 
         See https://github.com/gonzalo-bulnes/simple_token_authentication/issues/158

--- a/simple_token_authentication.gemspec
+++ b/simple_token_authentication.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "inch", "~> 0.4"
   s.add_development_dependency "activerecord", ">= 3.2.6", "< 7"
-  s.add_development_dependency 'mongoid', '>= 3.1.0', '< 7'
+  s.add_development_dependency 'mongoid', ">= 3.1.0", "< 8"
   s.add_development_dependency "appraisal", "~> 2.0"
 end

--- a/spec/lib/simple_token_authentication/adapters/mongoid_adapter_spec.rb
+++ b/spec/lib/simple_token_authentication/adapters/mongoid_adapter_spec.rb
@@ -1,28 +1,21 @@
-if Module.const_defined?('ActiveModel') &&
-  ActiveModel.const_defined?('Serializers') &&
-  ActiveModel::Serializers.const_defined?('Xml')
-  # As far as I know Mongoid doesn't support Rails 6
-  # Please let me know if this isn't true when you read it!
-
-  require 'spec_helper'
+require 'spec_helper'
   require 'simple_token_authentication/adapters/mongoid_adapter'
 
-  describe 'SimpleTokenAuthentication::Adapters::MongoidAdapter' do
+describe 'SimpleTokenAuthentication::Adapters::MongoidAdapter' do
 
-    before(:each) do
-      stub_const('Mongoid', Module.new)
-      stub_const('Mongoid::Document', double())
+  before(:each) do
+    stub_const('Mongoid', Module.new)
+    stub_const('Mongoid::Document', double())
 
-      @subject = SimpleTokenAuthentication::Adapters::MongoidAdapter
-    end
+    @subject = SimpleTokenAuthentication::Adapters::MongoidAdapter
+  end
 
-    it_behaves_like 'an adapter'
+  it_behaves_like 'an adapter'
 
-    describe '.base_class' do
+  describe '.base_class' do
 
-      it 'is Mongoid::Document', private: true do
-        expect(@subject.base_class).to eq Mongoid::Document
-      end
+    it 'is Mongoid::Document', private: true do
+      expect(@subject.base_class).to eq Mongoid::Document
     end
   end
 end


### PR DESCRIPTION
This reverts changes from 0c1a9a596731f4c8358a4874d9d6c54cfbc5017f and allows simple_token_authentication to be used with rails 6.0. With [mongoid version 7.0.5](https://github.com/gonzalo-bulnes/simple_token_authentication/issues/351#issuecomment-532764256) rails 6.0 support was added.

Fixes #351 #352 