### PR TITLE
Remove a deprecation warning with Rails 6

### DIFF
--- a/lib/simple_token_authentication/acts_as_token_authenticatable.rb
+++ b/lib/simple_token_authentication/acts_as_token_authenticatable.rb
@@ -32,7 +32,7 @@ module SimpleTokenAuthentication
     end
 
     def token_suitable?(token)
-      self.class.where(authentication_token: token).count == 0
+      self.class.unscoped.where(authentication_token: token).count == 0
     end
 
     def token_generator


### PR DESCRIPTION
Adding a simple unscoped on this line avoids firing a Deprecation warning for classes using acts_as_token_authenticatable