### PR TITLE
fix: do not use blank implementation for hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ To use no fallback when token authentication fails, set `fallback: :none`.
 
 ### Hooks
 
-One hook is currently available to trigger custom behaviour after an user has been successfully authenticated through token authentication. To use it, override the `after_successful_token_authentication` method in the corresponding token authentication handler:
+One hook is currently available to trigger custom behaviour after an user has been successfully authenticated through token authentication. To use it, implement or mixin a module with an `after_successful_token_authentication` method that will be ran after authentication from a token authentication handler:
 
 ```ruby
 # app/controller/application_controller.rb

--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -27,20 +27,12 @@ module SimpleTokenAuthentication
       private :integrate_with_devise_case_insensitive_keys
     end
 
-    # This method is a hook and is meant to be overridden.
-    #
-    # It is not expected to return anything special,
-    # only its side effects will be used.
-    def after_successful_token_authentication
-      # intentionally left blank
-    end
-
     def authenticate_entity_from_token!(entity)
       record = find_record_from_identifier(entity)
 
       if token_correct?(record, entity, token_comparator)
         perform_sign_in!(record, sign_in_handler)
-        after_successful_token_authentication
+        after_successful_token_authentication if respond_to?(:after_successful_token_authentication)
       end
     end
 

--- a/simple_token_authentication.gemspec
+++ b/simple_token_authentication.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "inch", "~> 0.4"
   s.add_development_dependency "activerecord", ">= 3.2.6", "< 7"
-  s.add_development_dependency 'mongoid', ">= 3.1.0", "< 8"
+  s.add_development_dependency 'mongoid', ">= 4", "< 9"
   s.add_development_dependency "appraisal", "~> 2.0"
 end

--- a/spec/lib/simple_token_authentication/adapters/mongoid_adapter_spec.rb
+++ b/spec/lib/simple_token_authentication/adapters/mongoid_adapter_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-  require 'simple_token_authentication/adapters/mongoid_adapter'
+require 'simple_token_authentication/adapters/mongoid_adapter'
 
 describe 'SimpleTokenAuthentication::Adapters::MongoidAdapter' do
 

--- a/spec/support/specs_for_token_authentication_handler_interface.rb
+++ b/spec/support/specs_for_token_authentication_handler_interface.rb
@@ -7,9 +7,8 @@ RSpec.shared_examples 'a token authentication handler' do
   end
 
   describe 'instance' do
-
-    it 'responds to :after_successful_token_authentication', hooks: true, private: true do
-      expect(token_authentication_handler.new).to respond_to :after_successful_token_authentication
+    it 'does not implement :after_successful_token_authentication by default', private: true do
+      expect(token_authentication_handler.new).not_to respond_to :after_successful_token_authentication
     end
   end
 end


### PR DESCRIPTION
Same PR as https://github.com/gonzalo-bulnes/simple_token_authentication/pull/333 but more recent

Do not use a blank implementation for hooks that would override exiistng ones if they were declared before the acts_as_token_authentication_handler_for method (eg. via a mixin)

Fix for https://github.com/gonzalo-bulnes/simple_token_authentication/issues/217#issuecomment-378886251

UPDATE:

I also ran into a problem with tests on recent rails versions

> uninitialized constant ActiveModel::Serializers::Xml

It seems like some libraries are not added anymore by default in Rails, and this causes incompatibility with old mongoid versions that use the "moped" driver (instead of the more recent mongo driver). I have slightly bumped the mongoid version in the Gemspec, but I think mongoid ensures the rails version matches in this aspect anyways so there should ne be problem for end users, only when testing.