### PR TITLE
Add Rails 7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
           - '2.6'
           - '1.9.3'
         gemfile:
+          - rails_7_devise_4
           - rails_6_devise_4
           - rails_5_devise_4
           - rails_4_devise_3
@@ -31,6 +32,8 @@ jobs:
             gemfile: rails_4_devise_3
           - ruby: 2.7
             gemfile: ruby_1.9.3_rails_3.2
+          - ruby: 2.6
+            gemfile: rails_7_devise_4
           - ruby: 2.6
             gemfile: rails_6_devise_4
           - ruby: 2.6

--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,18 @@
-appraise 'rails_6_devise_4' do
+appraise 'rails_7_devise_4' do
   # use gemspec constraints
+end
+
+appraise 'rails_6_devise_4' do
+  gem "actionmailer", "~> 6.0"
+  gem "actionpack", "~> 6.0"
+  gem "devise", "~> 4.0"
 end
 
 appraise 'rails_5_devise_4' do
   gem 'actionmailer', '~> 5.0'
   gem 'actionpack', '~> 5.0'
   gem 'activerecord', '~> 5.0'
+  gem "devise", "~> 4.0"
 end
 
 appraise 'rails_4_devise_3' do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Add Rails 7 support - @OskarEichler
+
 ## [1.17.0] - 2019-09-21
 
 ### Added

--- a/gemfiles/rails_5_devise_4.gemfile
+++ b/gemfiles/rails_5_devise_4.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem "actionmailer", "~> 5.0"
 gem "actionpack", "~> 5.0"
 gem "activerecord", "~> 5.0"
+gem "devise", "~> 4.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_devise_4.gemfile
+++ b/gemfiles/rails_7_devise_4.gemfile
@@ -2,8 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "actionmailer", "~> 6.0"
-gem "actionpack", "~> 6.0"
-gem "devise", "~> 4.0"
-
 gemspec path: "../"

--- a/simple_token_authentication.gemspec
+++ b/simple_token_authentication.gemspec
@@ -16,13 +16,13 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,doc,lib}/**/*", "CHANGELOG.md", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*", "gemfiles/*.gemfile", "gemfiles/*.gemfile.lock", "Appraisals"]
 
-  s.add_dependency "actionmailer", ">= 3.2.6", "< 7"
-  s.add_dependency "actionpack", ">= 3.2.6", "< 7"
+  s.add_dependency "actionmailer", ">= 3.2.6", "< 8"
+  s.add_dependency "actionpack", ">= 3.2.6", "< 8"
   s.add_dependency "devise", ">= 3.2", "< 6"
 
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "inch", "~> 0.4"
-  s.add_development_dependency "activerecord", ">= 3.2.6", "< 7"
+  s.add_development_dependency "activerecord", ">= 3.2.6", "< 8"
   s.add_development_dependency 'mongoid', ">= 3.1.0", "< 8"
   s.add_development_dependency "appraisal", "~> 2.0"
 end


### PR DESCRIPTION
This is a replay of #391, please continue the conversation over there. :slightly_smiling_face: 

----

@OskarEichler I rebased and edited the commit history of your branch. I was about to push to it, until I realized that's your fork's `master` branch. I'd rather not modify it, especially since you told me you and others refer to it for installing the gem. So I opened this PR instead.

What I did:

- I rebased the branch onto the latest `master`
  - That adds a Ruby 1.9.3 job to the [Test](https://github.com/gonzalo-bulnes/simple_token_authentication/actions/runs/3784715516) workflow (so we're full on par with old Travis CI)
  - and some unrelated README updates
  - That also removes the merge commits, which should make the branch easier to use as a reference next time someone want to upgrade Rails support.
- I grouped some of your commits for increased readability
- I removed a few (e.g. adding [new dependencies wasn't needed after all](https://github.com/gonzalo-bulnes/simple_token_authentication/pull/391#issuecomment-1365487719))
- I adjusted the version constraints in the test gemfiles (and sneaked in a Devise constraint that I missed long ago)

I worked from your commits, so they are properly attributed. For transparency, I added myself as a co-author to the ones I edited significantly.

Closes #391 