### PR TITLE
fix: do not use blank implementation for hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Add Rails 7 support - @OskarEichler
+- Fix undesirable override of hooks by (no-op) default implementation - @Startouf
 
 ## [1.17.0] - 2019-09-21
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ To use no fallback when token authentication fails, set `fallback: :none`.
 
 ### Hooks
 
-One hook is currently available to trigger custom behaviour after an user has been successfully authenticated through token authentication. To use it, override the `after_successful_token_authentication` method in the corresponding token authentication handler:
+One hook is currently available to trigger custom behaviour after an user has been successfully authenticated through token authentication. To use it, implement or mixin a module with an `after_successful_token_authentication` method that will be ran after authentication from a token authentication handler:
 
 ```ruby
 # app/controller/application_controller.rb

--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -27,20 +27,12 @@ module SimpleTokenAuthentication
       private :integrate_with_devise_case_insensitive_keys
     end
 
-    # This method is a hook and is meant to be overridden.
-    #
-    # It is not expected to return anything special,
-    # only its side effects will be used.
-    def after_successful_token_authentication
-      # intentionally left blank
-    end
-
     def authenticate_entity_from_token!(entity)
       record = find_record_from_identifier(entity)
 
       if token_correct?(record, entity, token_comparator)
         perform_sign_in!(record, sign_in_handler)
-        after_successful_token_authentication
+        after_successful_token_authentication if respond_to?(:after_successful_token_authentication)
       end
     end
 

--- a/simple_token_authentication.gemspec
+++ b/simple_token_authentication.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "inch", "~> 0.4"
   s.add_development_dependency "activerecord", ">= 3.2.6", "< 8"
-  s.add_development_dependency 'mongoid', ">= 3.1.0", "< 8"
+  s.add_development_dependency 'mongoid', ">= 4", "< 9"
   s.add_development_dependency "appraisal", "~> 2.0"
 end

--- a/simple_token_authentication.gemspec
+++ b/simple_token_authentication.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "inch", "~> 0.4"
   s.add_development_dependency "activerecord", ">= 3.2.6", "< 8"
-  s.add_development_dependency 'mongoid', ">= 4", "< 9"
+  s.add_development_dependency 'mongoid', ">= 3.1.0", "< 9"
   s.add_development_dependency "appraisal", "~> 2.0"
 end

--- a/spec/lib/simple_token_authentication/adapters/mongoid_adapter_spec.rb
+++ b/spec/lib/simple_token_authentication/adapters/mongoid_adapter_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-  require 'simple_token_authentication/adapters/mongoid_adapter'
+require 'simple_token_authentication/adapters/mongoid_adapter'
 
 describe 'SimpleTokenAuthentication::Adapters::MongoidAdapter' do
 

--- a/spec/support/specs_for_token_authentication_handler_interface.rb
+++ b/spec/support/specs_for_token_authentication_handler_interface.rb
@@ -7,9 +7,8 @@ RSpec.shared_examples 'a token authentication handler' do
   end
 
   describe 'instance' do
-
-    it 'responds to :after_successful_token_authentication', hooks: true, private: true do
-      expect(token_authentication_handler.new).to respond_to :after_successful_token_authentication
+    it 'does not implement :after_successful_token_authentication by default', private: true do
+      expect(token_authentication_handler.new).not_to respond_to :after_successful_token_authentication
     end
   end
 end


### PR DESCRIPTION
This PR is a replay of #376, please let's continue the conversation over there.

----

@Startouf I've rebased your branch onto the latest `master` that now runs CI again. And I've restored the lower bound of the `mongoid` version constraint. I figure that the upper bound was more likely to have allowed you to fix the bug you fond, and the lower bound allows **mongoid 3.1.7** to be installed with Ruby 1.9.3. 

I don't believe that anyone would be still using it, but I'm [preserving backwards-compatibility](https://github.com/gonzalo-bulnes/simple_token_authentication/commit/78a3a5736759dc3e5902f6b0226d26df217b5065).

Close #376