### PR TITLE
fix: handle private hook implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix a regression introduced by #402, that caused hooks not to be invoked - @dmke
+
 ## [1.18.0] - 2022-12-27
 
 ### Added

--- a/lib/simple_token_authentication/token_authentication_handler.rb
+++ b/lib/simple_token_authentication/token_authentication_handler.rb
@@ -32,7 +32,7 @@ module SimpleTokenAuthentication
 
       if token_correct?(record, entity, token_comparator)
         perform_sign_in!(record, sign_in_handler)
-        after_successful_token_authentication if respond_to?(:after_successful_token_authentication)
+        after_successful_token_authentication if respond_to?(:after_successful_token_authentication, true)
       end
     end
 

--- a/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
+++ b/spec/lib/simple_token_authentication/token_authentication_handler_spec.rb
@@ -736,6 +736,21 @@ describe 'Any class which includes SimpleTokenAuthentication::TokenAuthenticatio
           expect(token_authentication_handler).to have_received(:after_successful_token_authentication).once
         end
       end
+
+      context 'when the handler implements a private :after_successful_token_authentication', protected: true do
+        before(:each) do
+          token_authentication_handler.singleton_class.send(:include, Module.new {
+            def after_successful_token_authentication; end
+            private :after_successful_token_authentication
+          })
+          allow(token_authentication_handler).to receive(:after_successful_token_authentication)
+        end
+
+        it 'calls the :after_successful_token_authentication hook' do
+          token_authentication_handler.send(:authenticate_entity_from_token!, double)
+          expect(token_authentication_handler).to have_received(:after_successful_token_authentication).once
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes a regression introduced in #402.

Details: https://github.com/gonzalo-bulnes/simple_token_authentication/pull/402#issuecomment-1369269890